### PR TITLE
Prepare Maven Central publication workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ jobs:
           distribution: temurin
           java-version: "21"
           cache: maven
+      - name: Test release tooling
+        shell: bash
+        run: |
+          release_ci_version=$(./mvnw --quiet --no-transfer-progress \
+            help:evaluate -Dexpression=project.version -DforceStdout)
+          if [[ "$release_ci_version" == *-SNAPSHOT ]]; then
+            ./scripts/test-release-tooling.sh development
+          else
+            ./scripts/test-release-tooling.sh stable-tag "v$release_ci_version"
+          fi
       - run: ./mvnw --batch-mode --no-transfer-progress verify
       - run: ./scripts/smoke-test.sh
 

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -1,0 +1,133 @@
+name: Publish to Maven Central
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: maven-central-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+      - name: Validate immutable release identity
+        run: ./scripts/validate-release-tag.sh "$GITHUB_REF_NAME"
+      - name: Verify release commit is on main
+        run: ./scripts/assert-release-commit-on-main.sh "$GITHUB_SHA"
+      - name: Test release tooling
+        run: ./scripts/test-release-tooling.sh stable-tag "$GITHUB_REF_NAME"
+      - name: Build and test
+        run: ./mvnw --batch-mode --no-transfer-progress clean verify
+      - name: Exercise external recipe discovery
+        run: ./scripts/smoke-test.sh
+      - name: Verify reproducible upload-free release artifacts
+        run: ./scripts/verify-reproducible-release.sh "$GITHUB_REF_NAME"
+
+  publish:
+    if: github.repository == 'Devansh-ops/rewrite-spring-to-helidon'
+    needs: verify-release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    environment:
+      name: maven-central
+      url: https://central.sonatype.com/publishing/deployments
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Recheck release commit is on main
+        run: ./scripts/assert-release-commit-on-main.sh "$GITHUB_SHA"
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+      - name: Resolve and validate release identity
+        id: release
+        shell: bash
+        run: |
+          ./scripts/validate-release-tag.sh "$GITHUB_REF_NAME"
+          echo "version=${GITHUB_REF_NAME#v}" >>"$GITHUB_OUTPUT"
+      - name: Refuse an existing immutable version
+        run: ./scripts/assert-central-version-new.sh "${{ steps.release.outputs.version }}"
+      - name: Sign and publish to Maven Central
+        shell: bash
+        run: |
+          signing_home="$RUNNER_TEMP/release-signing-gnupg"
+          release_public_key="$RUNNER_TEMP/release-public-key.gpg"
+          cleanup_signing_home() {
+            gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+            rm -rf "$signing_home"
+          }
+          trap cleanup_signing_home EXIT
+
+          export GNUPGHOME="$signing_home"
+          mkdir -m 700 "$GNUPGHOME"
+          printf '%s\n' "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --quiet --import
+          unset MAVEN_GPG_PRIVATE_KEY
+          gpg --batch --quiet --export >"$release_public_key"
+          test -s "$release_public_key"
+
+          ./mvnw --batch-mode --no-transfer-progress -Prelease \
+            -Dcentral.skipPublishing=false -DskipTests clean deploy
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      - name: Validate the submitted bundle
+        shell: bash
+        env:
+          GNUPGHOME: ${{ runner.temp }}/release-verification-gnupg
+        run: |
+          mkdir -m 700 "$GNUPGHOME"
+          gpg --batch --quiet --import "$RUNNER_TEMP/release-public-key.gpg"
+          ./scripts/validate-release-bundle.sh "${{ steps.release.outputs.version }}"
+      - name: Attest release provenance
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: |
+            ${{ github.workspace }}/target/central-publishing/central-bundle.zip
+            ${{ github.workspace }}/target/rewrite-spring-to-helidon-${{ steps.release.outputs.version }}.jar
+            ${{ github.workspace }}/target/rewrite-spring-to-helidon-${{ steps.release.outputs.version }}-sources.jar
+            ${{ github.workspace }}/target/rewrite-spring-to-helidon-${{ steps.release.outputs.version }}-javadoc.jar
+            ${{ github.workspace }}/pom.xml
+      - name: Verify Maven Central readback
+        env:
+          GNUPGHOME: ${{ runner.temp }}/release-verification-gnupg
+          CENTRAL_READBACK_MAX_ATTEMPTS: "80"
+          CENTRAL_READBACK_RETRY_SECONDS: "15"
+          CENTRAL_READBACK_TIMEOUT_SECONDS: "1200"
+          CENTRAL_READBACK_REQUEST_TIMEOUT_SECONDS: "10"
+        run: ./scripts/verify-central-publication.sh "${{ steps.release.outputs.version }}" "${{ github.workspace }}/target/central-publishing/central-bundle.zip" "${{ github.workspace }}"
+      - name: Verify a clean Central-only consumer
+        env:
+          CENTRAL_SMOKE_MAX_ATTEMPTS: "24"
+          CENTRAL_SMOKE_RETRY_SECONDS: "15"
+          CENTRAL_SMOKE_REQUEST_TIMEOUT_SECONDS: "10"
+        run: ./scripts/central-consumer-smoke-test.sh "${{ steps.release.outputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes will be documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+
+- A protected, tag-only Maven Central publication pipeline with pinned build and GitHub Action
+  dependencies, signed source/Javadoc artifacts, full checksums, GitHub build provenance,
+  immutable-version guards, byte-bound cryptographic Central readback, and a clean Central-only
+  consumer smoke test.
+- Local release-bundle validation and maintainer documentation for Central namespace, signing-key,
+  environment-protection, and secret setup.
+- A fail-closed `origin/main` ancestry guard and an upload-free two-build comparison of the exact
+  unsigned main, sources, Javadoc, and published POM artifacts.
+- Explicit development and stable-tag release-tooling contracts, exercised in ordinary CI with
+  publishing disabled unless the protected release workflow opts in.
+
+### Changed
+
+- Development metadata now uses `0.2.1-SNAPSHOT` and SCM tag `HEAD`. Version `0.2.0` remains a
+  source-only GitHub release and is not represented as a Maven Central publication.
+
 ## [0.2.0] - 2026-08-20
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,25 @@ Run focused tests while developing, followed by the complete suite:
 ./scripts/transaction-contract-test.sh
 ```
 
+Release-tooling changes must also pass:
+
+```bash
+./scripts/test-release-tooling.sh development
+```
+
+The development mode requires a `MAJOR.MINOR.PATCH-SNAPSHOT` project version and SCM tag `HEAD`.
+When reviewing prepared stable metadata, use the explicit tag instead:
+
+```bash
+./scripts/test-release-tooling.sh stable-tag v0.2.1
+```
+
+Before a stable tag is pushed, maintainers also run the upload-free two-build reproducibility check
+documented in [the Maven Central release process](docs/publishing.md).
+
+Publishing credentials and signing keys must never be used from a pull request or stored in the
+repository. Maintainers should follow [the protected Maven Central release process](docs/publishing.md).
+
 ## Pull requests
 
 Keep pull requests focused and explain the source semantics, target semantics, refusal boundary,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ separately reviewed steps.
 > pipeline. Always use an isolated branch, dry-run one leaf at a time, and compile and test the
 > affected module.
 
+> **Distribution status:** `0.2.0` remains a source-only GitHub release and has never been
+> published to Maven Central. The repository is currently on `0.2.1-SNAPSHOT` and includes a
+> protected, signed Central publication pipeline for the next release. See
+> [publishing to Maven Central](docs/publishing.md) for the credential gate and release process.
+
 ## In plain English
 
 This project first answers: “Where does this application depend on Spring, and which target API

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,176 @@
+# Publishing to Maven Central
+
+This project is prepared to publish signed releases under
+`io.github.devansh-ops:rewrite-spring-to-helidon`. Publication is intentionally gated by a GitHub
+environment and a stable Git tag. Pull requests, Dependabot branches, ordinary branch pushes, and
+manual workflow dispatches cannot enter the publication job.
+
+Version `0.2.0` was released through GitHub as source only. It has not been published to Maven
+Central, and this project must never imply otherwise. The development POM starts at
+`0.2.1-SNAPSHOT`; the first Central release must use an unpublished version such as `0.2.1` or
+later.
+
+Maven Central releases are immutable. Treat every attempt that may have reached the Central Portal
+as consumed, even if a later workflow step failed. Fix the problem and choose a new version rather
+than trying to replace published bytes.
+
+## One-time publisher setup
+
+These steps require the repository owner because they create external credentials and protection
+rules. Do not paste any resulting token, private key, or passphrase into an issue, pull request,
+repository file, build log, or chat.
+
+1. Sign in to the [Central Publisher Portal](https://central.sonatype.com/) with the GitHub identity
+   that controls `Devansh-ops`.
+2. Confirm that the `io.github.devansh-ops` namespace is verified. Central often provisions the
+   matching personal GitHub namespace automatically. If it does not, follow Central's
+   [namespace verification](https://central.sonatype.org/register/namespace/) flow and create only
+   the temporary public repository whose exact name Central supplies. Delete that temporary
+   repository after verification.
+3. Generate a passphrase-protected OpenPGP key whose public identity is appropriate for this
+   project. Central's current guidance requires signing with the primary key. Publish the public
+   key to a supported server such as `keyserver.ubuntu.com`; see Central's
+   [GPG instructions](https://central.sonatype.org/publish/requirements/gpg/). Keep an encrypted,
+   offline backup of the private key and its revocation certificate.
+4. Generate a Central Portal user token. The token provides a username and password; it is not the
+   interactive portal password.
+5. In GitHub, create or verify an environment named exactly `maven-central` with:
+
+   - deployment tags restricted to protected release tags matching `v*.*.*` (GitHub environment
+     tag filters are globs; the workflow's exact `vMAJOR.MINOR.PATCH` guard is authoritative);
+   - required approval from `Devansh-ops`;
+   - a 5-minute wait timer;
+   - prevention of self-review when that would not make releases impossible; and
+   - administrator bypass disabled where the repository's plan and ownership model permit it.
+
+   GitHub withholds environment secrets until its protection rules pass. See
+   [GitHub's environment documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments).
+
+6. Add these four **environment secrets** to `maven-central`, not repository-wide secrets:
+
+   | Secret | Value |
+   | --- | --- |
+   | `MAVEN_CENTRAL_USERNAME` | Username from the Central Portal user token |
+   | `MAVEN_CENTRAL_TOKEN` | Password from the Central Portal user token |
+   | `MAVEN_GPG_PRIVATE_KEY` | ASCII-armored export of the primary private key |
+   | `MAVEN_GPG_PASSPHRASE` | Passphrase protecting that private key |
+
+The workflow gives its default token only `contents: read`. The protected publication job adds only
+the OIDC and attestation permissions needed for GitHub build provenance. Every external action is
+pinned to a complete commit SHA, checkout credentials are not persisted, and Central credentials
+are passed to the Maven publication step through environment variables only. The private signing
+key is imported into an isolated temporary GPG home for that step and erased when the step exits;
+later bundle and readback checks use only the exported public key.
+
+## Prepare a release
+
+Work from a reviewed commit on `main`.
+
+1. Replace `0.2.1-SNAPSHOT` with the intended stable version in `pom.xml`.
+2. Replace the POM SCM tag `HEAD` with the exact tag, for example `v0.2.1`.
+3. Update `CHANGELOG.md` and release-facing README text. Do not state that a version is on Central
+   before readback succeeds.
+4. Run the normal checks:
+
+   ```bash
+   ./mvnw --batch-mode --no-transfer-progress clean verify
+   ./scripts/smoke-test.sh
+   ./scripts/test-release-tooling.sh stable-tag v0.2.1
+   ```
+
+5. With a disposable or real signing key available in the local GPG keyring, build the exact
+   Central bundle without uploading it:
+
+   ```bash
+   ./scripts/build-release-bundle-locally.sh v0.2.1
+   ```
+
+   This command stops at Maven `verify` with `central.skipPublishing=true`, then assembles and
+   validates a clearly named Central-layout structural test bundle containing the main JAR,
+   sources JAR, Javadoc JAR, POM, detached signatures, and
+   MD5/SHA-1/SHA-256/SHA-512 checksums. The local surrogate does not invoke the plugin's staging or
+   upload path and is not evidence that Central accepted the bundle. Only the protected publish job
+   validates the Sonatype plugin-produced bundle.
+6. Verify the unsigned primary artifacts and published POM are reproducible across two isolated,
+   upload-free builds:
+
+   ```bash
+   ./scripts/verify-reproducible-release.sh v0.2.1
+   ```
+
+   This comparison intentionally excludes detached signatures and the aggregate bundle because
+   signing metadata is not byte-reproducible.
+7. Merge the release metadata to `main`, create the exact `vMAJOR.MINOR.PATCH` tag on that commit,
+   and push the tag. Tag creation is deliberately outside the publication workflow. A tag whose
+   commit is not reachable from `origin/main` is rejected.
+
+## What the tag workflow does
+
+`.github/workflows/publish-central.yml` has two jobs:
+
+1. `verify-release` runs without publisher credentials. It fetches full history, proves the tag
+   commit is reachable from `origin/main`, validates the exact tag/POM/SCM relationship, exercises
+   all release guards, runs the project tests and external recipe smoke test, and byte-compares the
+   main, sources, Javadoc, and published POM from two isolated upload-free builds. Each build uses
+   its own clean project copy, Maven repository, home directories, and disposable signing key.
+2. `publish` waits at the protected `maven-central` environment. After approval it checks that the
+   exact coordinate does not already exist, imports the protected signing key into a temporary
+   keyring for the Maven step, and runs the pinned Sonatype `central-publishing-maven-plugin`
+   `0.11.0`. The plugin auto-publishes and waits up to 120 minutes for the `PUBLISHED` state,
+   polling every 10 seconds. All readback downloads share one 20-minute deadline and use
+   10-second request caps. The clean consumer probe uses at most 24 attempts with 15-second pauses
+   and 10-second request caps, keeping its repository-visibility wait below 10 minutes. These
+   limits leave roughly 30 minutes of the publication job's 180-minute timeout for the build,
+   attestation, and final consumer execution. A public-key-only keyring is retained for
+   verification; the temporary private-key material is removed.
+
+After upload, the job validates the generated bundle, creates a GitHub/Sigstore build-provenance
+attestation, downloads every published file back from Maven Central to verify its checksums and
+signatures, and finally runs the recipe from a clean external Maven project whose isolated local
+repository is mirrored exclusively to `https://repo.maven.apache.org/maven2`.
+
+The preflight duplicate check is an early guard, not a substitute for Central's immutability
+enforcement. The plugin keeps `ignorePublishedComponents=false`, so Central remains authoritative
+if two attempts race.
+
+## Verify a published release
+
+The workflow performs both commands automatically after Central reports `PUBLISHED`:
+
+```bash
+./scripts/verify-central-publication.sh 0.2.1 \
+  target/central-publishing/central-bundle.zip .
+./scripts/central-consumer-smoke-test.sh 0.2.1
+```
+
+`verify-central-publication.sh` requires the publisher's public key in the local GPG keyring. It
+first proves that the plugin-produced bundle contains the exact local main JAR, sources JAR,
+Javadoc JAR, and POM. It downloads those four files, their signatures, and every checksum from
+Central, validates them, and byte-compares all four downloads with the submitted bundle before
+printing their SHA-256 digests. `central-consumer-smoke-test.sh` creates a temporary consumer and
+temporary Maven repository and refuses to use `mavenLocal` or any non-Central mirror.
+
+GitHub provenance can be checked separately after downloading an attested artifact:
+
+```bash
+gh attestation verify rewrite-spring-to-helidon-0.2.1.jar \
+  --repo Devansh-ops/rewrite-spring-to-helidon
+```
+
+## Failure handling
+
+- If `verify-release` fails, do not approve the environment. Correct the release metadata and use a
+  new reviewed tag according to the repository's release policy.
+- If the duplicate guard finds the coordinate, stop. Central artifacts cannot be overwritten.
+- If Maven reports an upload, validation, or publishing failure, inspect the Central Portal before
+  retrying. If the deployment could have published, increment the version.
+- If provenance or readback fails after `PUBLISHED`, the Central artifact still exists and is
+  immutable. Preserve the logs, fix the pipeline, and publish a new patch version if artifact bytes
+  or metadata are wrong.
+- Rotate the Central token or GPG key by replacing the environment secret. Never commit a local
+  Maven `settings.xml`, exported private key, passphrase, or token.
+
+The required artifact set and metadata follow Central's
+[publishing requirements](https://central.sonatype.org/publish/requirements/), and the release
+profile follows the supported
+[Central Maven plugin](https://central.sonatype.org/publish/publish-portal-maven/) workflow.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.devansh-ops</groupId>
     <artifactId>rewrite-spring-to-helidon</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
     <name>OpenRewrite Spring Boot to Helidon MP recipes</name>
     <description>Mechanical and assessment recipes for migrating Spring Boot applications to Helidon MP.</description>
     <url>https://github.com/Devansh-ops/rewrite-spring-to-helidon</url>
@@ -30,13 +30,14 @@
         <connection>scm:git:https://github.com/Devansh-ops/rewrite-spring-to-helidon.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/Devansh-ops/rewrite-spring-to-helidon.git</developerConnection>
         <url>https://github.com/Devansh-ops/rewrite-spring-to-helidon</url>
-        <tag>v0.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.outputTimestamp>2026-08-20T00:00:00Z</project.build.outputTimestamp>
+        <central.skipPublishing>true</central.skipPublishing>
         <maven.compiler.release>8</maven.compiler.release>
         <maven.compiler.testRelease>21</maven.compiler.testRelease>
         <rewrite-recipe-bom.version>3.37.0</rewrite-recipe-bom.version>
@@ -251,4 +252,105 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-release-version</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseVersion>
+                                            <message>The release profile cannot publish a SNAPSHOT project version.</message>
+                                        </requireReleaseVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.12.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.8</version>
+                        <executions>
+                            <execution>
+                                <id>sign-release-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <bestPractices>true</bestPractices>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>3.1.4</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.11.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <waitMaxTime>7200</waitMaxTime>
+                            <waitPollingInterval>10</waitPollingInterval>
+                            <checksums>all</checksums>
+                            <failOnBuildFailure>true</failOnBuildFailure>
+                            <ignorePublishedComponents>false</ignorePublishedComponents>
+                            <skipPublishing>${central.skipPublishing}</skipPublishing>
+                            <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/scripts/assemble-central-layout-test-bundle.sh
+++ b/scripts/assemble-central-layout-test-bundle.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+central_test_bundle_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+central_test_bundle_project_dir=$(CDPATH= cd -- "$central_test_bundle_script_dir/.." && pwd)
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  echo "Usage: $0 <MAJOR.MINOR.PATCH> [pom.xml] [test-bundle.zip]" >&2
+  exit 2
+fi
+
+central_test_bundle_version=$1
+central_test_bundle_pom=${2:-"$central_test_bundle_project_dir/pom.xml"}
+central_test_bundle_basedir=$(CDPATH= cd -- "$(dirname -- "$central_test_bundle_pom")" && pwd)
+central_test_bundle_output=${3:-"$central_test_bundle_basedir/target/release-validation/central-layout-test-bundle.zip"}
+
+if [[ ! "$central_test_bundle_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Central-layout test bundle version must use the exact stable form MAJOR.MINOR.PATCH: $central_test_bundle_version" >&2
+  exit 1
+fi
+
+if [[ ! -s "$central_test_bundle_pom" ]]; then
+  echo "Release POM does not exist or is empty: $central_test_bundle_pom" >&2
+  exit 1
+fi
+
+central_test_bundle_tmp_dir=$(mktemp -d)
+trap 'rm -rf "$central_test_bundle_tmp_dir"' EXIT
+central_test_bundle_coordinate_path="io/github/devansh-ops/rewrite-spring-to-helidon/$central_test_bundle_version"
+central_test_bundle_staging_dir="$central_test_bundle_tmp_dir/$central_test_bundle_coordinate_path"
+central_test_bundle_prefix="$central_test_bundle_staging_dir/rewrite-spring-to-helidon-$central_test_bundle_version"
+central_test_bundle_target_prefix="$central_test_bundle_basedir/target/rewrite-spring-to-helidon-$central_test_bundle_version"
+mkdir -p "$central_test_bundle_staging_dir" "$(dirname -- "$central_test_bundle_output")"
+
+for central_test_bundle_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  central_test_bundle_destination="$central_test_bundle_prefix$central_test_bundle_suffix"
+  if [[ "$central_test_bundle_suffix" == .pom ]]; then
+    central_test_bundle_source=$central_test_bundle_pom
+  else
+    central_test_bundle_source="$central_test_bundle_target_prefix$central_test_bundle_suffix"
+  fi
+  central_test_bundle_signature="$central_test_bundle_target_prefix$central_test_bundle_suffix.asc"
+
+  if [[ ! -s "$central_test_bundle_source" ]]; then
+    echo "Missing primary release artifact for structural bundle: $central_test_bundle_source" >&2
+    exit 1
+  fi
+  if [[ ! -s "$central_test_bundle_signature" ]]; then
+    echo "Missing detached release signature for structural bundle: $central_test_bundle_signature" >&2
+    exit 1
+  fi
+
+  cp "$central_test_bundle_source" "$central_test_bundle_destination"
+  cp "$central_test_bundle_signature" "$central_test_bundle_destination.asc"
+  md5sum "$central_test_bundle_destination" | awk '{ print $1 }' >"$central_test_bundle_destination.md5"
+  sha1sum "$central_test_bundle_destination" | awk '{ print $1 }' >"$central_test_bundle_destination.sha1"
+  sha256sum "$central_test_bundle_destination" | awk '{ print $1 }' >"$central_test_bundle_destination.sha256"
+  sha512sum "$central_test_bundle_destination" | awk '{ print $1 }' >"$central_test_bundle_destination.sha512"
+done
+
+(
+  cd "$central_test_bundle_tmp_dir"
+  jar --create --file "$central_test_bundle_output" .
+)
+
+echo "Created Central-layout structural test bundle: $central_test_bundle_output"
+echo "This local surrogate does not prove Sonatype Central plugin staging behavior."

--- a/scripts/assert-central-version-new.sh
+++ b/scripts/assert-central-version-new.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+central_guard_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+central_guard_project_dir=$(CDPATH= cd -- "$central_guard_script_dir/.." && pwd)
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <MAJOR.MINOR.PATCH> [pom.xml]" >&2
+  exit 2
+fi
+
+central_guard_version=$1
+central_guard_pom=${2:-"$central_guard_project_dir/pom.xml"}
+central_guard_repository_url=${CENTRAL_REPOSITORY_URL:-https://repo.maven.apache.org/maven2}
+central_guard_curl=${CURL_BIN:-curl}
+
+if [[ ! "$central_guard_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Maven Central version must use the exact stable form MAJOR.MINOR.PATCH: $central_guard_version" >&2
+  exit 1
+fi
+
+central_guard_pom_version=$("$central_guard_project_dir/mvnw" --quiet --no-transfer-progress \
+  -f "$central_guard_pom" help:evaluate -Dexpression=project.version -DforceStdout)
+central_guard_group_id=$("$central_guard_project_dir/mvnw" --quiet --no-transfer-progress \
+  -f "$central_guard_pom" help:evaluate -Dexpression=project.groupId -DforceStdout)
+central_guard_artifact_id=$("$central_guard_project_dir/mvnw" --quiet --no-transfer-progress \
+  -f "$central_guard_pom" help:evaluate -Dexpression=project.artifactId -DforceStdout)
+
+if [[ "$central_guard_pom_version" != "$central_guard_version" ]]; then
+  echo "Requested Central version $central_guard_version does not match Maven version $central_guard_pom_version." >&2
+  exit 1
+fi
+
+central_guard_group_path=${central_guard_group_id//./\/}
+central_guard_coordinate="$central_guard_group_id:$central_guard_artifact_id:$central_guard_version"
+central_guard_artifact_url="${central_guard_repository_url%/}/$central_guard_group_path/$central_guard_artifact_id/$central_guard_version/$central_guard_artifact_id-$central_guard_version.pom"
+
+if ! central_guard_http_status=$("$central_guard_curl" --silent --show-error --location \
+    --output /dev/null --write-out '%{http_code}' "$central_guard_artifact_url"); then
+  echo "Could not prove that $central_guard_coordinate is unpublished: Maven Central could not be queried." >&2
+  exit 1
+fi
+
+case "$central_guard_http_status" in
+  404)
+    echo "Maven Central does not contain $central_guard_coordinate; the immutable version is available."
+    ;;
+  200)
+    echo "Maven Central already contains $central_guard_coordinate; published versions are immutable." >&2
+    exit 1
+    ;;
+  *)
+    echo "Could not prove that $central_guard_coordinate is unpublished: Maven Central returned HTTP $central_guard_http_status." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/assert-release-commit-on-main.sh
+++ b/scripts/assert-release-commit-on-main.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <40-character-commit-sha>" >&2
+  exit 2
+fi
+
+release_main_commit=$1
+release_main_git=${GIT_BIN:-git}
+
+if [[ ! "$release_main_commit" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release commit must be an exact lowercase 40-character Git SHA: $release_main_commit" >&2
+  exit 1
+fi
+
+if "$release_main_git" merge-base --is-ancestor "$release_main_commit" origin/main; then
+  echo "Release commit $release_main_commit is reachable from origin/main."
+else
+  release_main_status=$?
+  if [[ $release_main_status -eq 1 ]]; then
+    echo "Release commit $release_main_commit is not reachable from origin/main." >&2
+  else
+    echo "Could not prove that release commit $release_main_commit is reachable from origin/main." >&2
+  fi
+  exit 1
+fi

--- a/scripts/build-release-bundle-locally.sh
+++ b/scripts/build-release-bundle-locally.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+local_bundle_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+local_bundle_project_dir=$(CDPATH= cd -- "$local_bundle_script_dir/.." && pwd)
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <vMAJOR.MINOR.PATCH> [pom.xml]" >&2
+  exit 2
+fi
+
+local_bundle_tag=$1
+local_bundle_pom=${2:-"$local_bundle_project_dir/pom.xml"}
+local_bundle_maven=${MAVEN_BIN:-"$local_bundle_project_dir/mvnw"}
+local_bundle_file=${RELEASE_BUNDLE_FILE:-"$(dirname -- "$local_bundle_pom")/target/release-validation/central-layout-test-bundle.zip"}
+
+"$local_bundle_script_dir/validate-release-tag.sh" "$local_bundle_tag" "$local_bundle_pom"
+local_bundle_version=${local_bundle_tag#v}
+
+"$local_bundle_maven" --batch-mode --no-transfer-progress -f "$local_bundle_pom" \
+  -Prelease -Dcentral.skipPublishing=true clean verify
+
+"$local_bundle_script_dir/assemble-central-layout-test-bundle.sh" \
+  "$local_bundle_version" "$local_bundle_pom" "$local_bundle_file"
+"$local_bundle_script_dir/validate-release-bundle.sh" "$local_bundle_version" "$local_bundle_file"
+
+echo "Local structural release-bundle validation passed for $local_bundle_tag. Nothing was uploaded."
+echo "Only the protected publish job validates the Sonatype plugin-produced bundle."

--- a/scripts/central-consumer-smoke-test.sh
+++ b/scripts/central-consumer-smoke-test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+central_smoke_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+central_smoke_project_dir=$(CDPATH= cd -- "$central_smoke_script_dir/.." && pwd)
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <MAJOR.MINOR.PATCH>" >&2
+  exit 2
+fi
+
+central_smoke_version=$1
+central_smoke_repository_url=${CENTRAL_REPOSITORY_URL:-https://repo.maven.apache.org/maven2}
+central_smoke_curl=${CURL_BIN:-curl}
+central_smoke_maven=${MAVEN_BIN:-"$central_smoke_project_dir/mvnw"}
+central_smoke_max_attempts=${CENTRAL_SMOKE_MAX_ATTEMPTS:-120}
+central_smoke_retry_seconds=${CENTRAL_SMOKE_RETRY_SECONDS:-15}
+central_smoke_request_timeout_seconds=${CENTRAL_SMOKE_REQUEST_TIMEOUT_SECONDS:-10}
+
+if [[ ! "$central_smoke_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Central consumer version must use the exact stable form MAJOR.MINOR.PATCH: $central_smoke_version" >&2
+  exit 1
+fi
+
+if [[ ! "$central_smoke_max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "CENTRAL_SMOKE_MAX_ATTEMPTS must be a positive integer." >&2
+  exit 2
+fi
+
+if [[ ! "$central_smoke_retry_seconds" =~ ^[0-9]+$ ]]; then
+  echo "CENTRAL_SMOKE_RETRY_SECONDS must be a non-negative integer." >&2
+  exit 2
+fi
+
+if [[ ! "$central_smoke_request_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "CENTRAL_SMOKE_REQUEST_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+
+central_smoke_coordinate="io.github.devansh-ops:rewrite-spring-to-helidon:$central_smoke_version"
+central_smoke_artifact_path="io/github/devansh-ops/rewrite-spring-to-helidon/$central_smoke_version"
+central_smoke_pom_url="${central_smoke_repository_url%/}/$central_smoke_artifact_path/rewrite-spring-to-helidon-$central_smoke_version.pom"
+
+central_smoke_attempt=1
+while true; do
+  central_smoke_http_status=000
+  if central_smoke_http_result=$("$central_smoke_curl" --silent --show-error --location \
+      --connect-timeout "$central_smoke_request_timeout_seconds" \
+      --max-time "$central_smoke_request_timeout_seconds" \
+      --output /dev/null --write-out '%{http_code}' "$central_smoke_pom_url"); then
+    central_smoke_http_status=$central_smoke_http_result
+  fi
+
+  if [[ "$central_smoke_http_status" == 200 ]]; then
+    break
+  fi
+
+  if (( central_smoke_attempt >= central_smoke_max_attempts )); then
+    echo "Maven Central did not expose $central_smoke_coordinate after $central_smoke_attempt attempts; last HTTP status was $central_smoke_http_status." >&2
+    exit 1
+  fi
+
+  sleep "$central_smoke_retry_seconds"
+  central_smoke_attempt=$((central_smoke_attempt + 1))
+done
+
+central_smoke_tmp_dir=$(mktemp -d)
+trap 'rm -rf "$central_smoke_tmp_dir"' EXIT
+central_smoke_fixture_dir="$central_smoke_tmp_dir/consumer"
+central_smoke_local_repository="$central_smoke_tmp_dir/maven-repository"
+central_smoke_settings="$central_smoke_tmp_dir/settings.xml"
+
+mkdir -p "$central_smoke_fixture_dir" "$central_smoke_local_repository"
+cp -R "$central_smoke_project_dir/src/it/smoke/." "$central_smoke_fixture_dir/"
+
+cat >"$central_smoke_settings" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <interactiveMode>false</interactiveMode>
+    <mirrors>
+        <mirror>
+            <id>central-only</id>
+            <name>Maven Central only</name>
+            <url>${central_smoke_repository_url%/}</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>
+EOF
+
+(
+  cd "$central_smoke_fixture_dir"
+  "$central_smoke_maven" --settings="$central_smoke_settings" \
+    -Dmaven.repo.local="$central_smoke_local_repository" \
+    --batch-mode --no-transfer-progress -U clean \
+    org.openrewrite.maven:rewrite-maven-plugin:6.46.1:dryRun \
+    -Drewrite.recipeArtifactCoordinates="$central_smoke_coordinate" \
+    -Drewrite.activeRecipes=io.github.devanshops.rewrite.helidon.SpringBoot4ToHelidonMp \
+    -Drewrite.exportDatatables=true
+)
+
+central_smoke_patch="$central_smoke_fixture_dir/target/rewrite/rewrite.patch"
+central_smoke_datatables_dir="$central_smoke_fixture_dir/target/rewrite/datatables"
+central_smoke_recipe_jar="$central_smoke_local_repository/$central_smoke_artifact_path/rewrite-spring-to-helidon-$central_smoke_version.jar"
+
+if [[ ! -s "$central_smoke_recipe_jar" ]]; then
+  echo "The isolated consumer did not resolve $central_smoke_coordinate from Maven Central." >&2
+  exit 1
+fi
+
+if [[ ! -s "$central_smoke_patch" ]]; then
+  echo "Expected the Central-only consumer to produce $central_smoke_patch" >&2
+  exit 1
+fi
+
+grep -Fq 'PARTIAL: Dependency injection -> Jakarta CDI and jakarta.inject' "$central_smoke_patch"
+grep -Fq 'MANUAL: Spring Java API [SPRING_JAVA_API]' "$central_smoke_patch"
+
+central_smoke_usage_table=$(find "$central_smoke_datatables_dir" -type f \
+  -name '*SpringUsageTable.csv' -print -quit 2>/dev/null || true)
+central_smoke_project_table=$(find "$central_smoke_datatables_dir" -type f \
+  -name '*MigrationAssessmentTable.csv' -print -quit 2>/dev/null || true)
+
+if [[ -z "$central_smoke_usage_table" || -z "$central_smoke_project_table" ]]; then
+  echo "The Central-only consumer did not export both migration assessment tables." >&2
+  exit 1
+fi
+
+grep -Fq 'PARTIAL' "$central_smoke_usage_table"
+grep -Fq 'SPRING_MAVEN_DEPENDENCY' "$central_smoke_project_table"
+grep -Fq 'SPRING_JAVA_API' "$central_smoke_project_table"
+
+echo "Central-only consumer smoke test passed for $central_smoke_coordinate."

--- a/scripts/test-release-bundle-membership.sh
+++ b/scripts/test-release-bundle-membership.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+membership_test_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+membership_test_tmp_dir=$(mktemp -d)
+trap 'rm -rf "$membership_test_tmp_dir"' EXIT
+
+membership_test_version=0.2.1
+membership_test_coordinate_path="io/github/devansh-ops/rewrite-spring-to-helidon/$membership_test_version"
+membership_test_prefix="$membership_test_coordinate_path/rewrite-spring-to-helidon-$membership_test_version"
+membership_test_root="$membership_test_tmp_dir/repository"
+membership_test_bundle="$membership_test_tmp_dir/large-central-bundle.zip"
+membership_test_fake_unzip="$membership_test_tmp_dir/sigpipe-unzip"
+membership_test_real_unzip=$(command -v unzip)
+
+mkdir -p "$membership_test_root/$membership_test_coordinate_path"
+
+for membership_test_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  membership_test_artifact="$membership_test_root/$membership_test_prefix$membership_test_suffix"
+  printf 'membership fixture %s\n' "$membership_test_suffix" >"$membership_test_artifact"
+  printf 'structural signature fixture\n' >"$membership_test_artifact.asc"
+  md5sum "$membership_test_artifact" | awk '{ print $1 }' >"$membership_test_artifact.md5"
+  sha1sum "$membership_test_artifact" | awk '{ print $1 }' >"$membership_test_artifact.sha1"
+  sha256sum "$membership_test_artifact" | awk '{ print $1 }' >"$membership_test_artifact.sha256"
+  sha512sum "$membership_test_artifact" | awk '{ print $1 }' >"$membership_test_artifact.sha512"
+done
+
+(
+  cd "$membership_test_root"
+  jar --create --file "$membership_test_bundle" .
+)
+
+cat >"$membership_test_fake_unzip" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == -Z1 && -p /dev/stdout ]]; then
+  printf '%s\n' 'io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.jar'
+  exit 141
+fi
+
+exec "$MEMBERSHIP_TEST_REAL_UNZIP" "$@"
+EOF
+chmod +x "$membership_test_fake_unzip"
+
+RELEASE_GPG_VERIFY=false UNZIP_BIN="$membership_test_fake_unzip" \
+  MEMBERSHIP_TEST_REAL_UNZIP="$membership_test_real_unzip" \
+  "$membership_test_script_dir/validate-release-bundle.sh" \
+  "$membership_test_version" "$membership_test_bundle"
+
+echo "Release-bundle membership validation passed without a pipefail/SIGPIPE false negative."

--- a/scripts/test-release-tooling.sh
+++ b/scripts/test-release-tooling.sh
@@ -1,0 +1,967 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+release_test_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+release_test_project_dir=$(CDPATH= cd -- "$release_test_script_dir/.." && pwd)
+release_test_fixture_pom="$release_test_project_dir/src/test/release-tooling/release-pom.xml"
+release_test_wrong_scm_pom="$release_test_project_dir/src/test/release-tooling/wrong-scm-tag-pom.xml"
+release_test_snapshot_pom="$release_test_project_dir/src/test/release-tooling/snapshot-pom.xml"
+release_test_guard="$release_test_script_dir/validate-release-tag.sh"
+release_test_bundle_validator="$release_test_script_dir/validate-release-bundle.sh"
+release_test_bundle_membership="$release_test_script_dir/test-release-bundle-membership.sh"
+release_test_central_guard="$release_test_script_dir/assert-central-version-new.sh"
+release_test_central_smoke="$release_test_script_dir/central-consumer-smoke-test.sh"
+release_test_central_readback="$release_test_script_dir/verify-central-publication.sh"
+release_test_local_bundle_builder="$release_test_script_dir/build-release-bundle-locally.sh"
+release_test_main_guard="$release_test_script_dir/assert-release-commit-on-main.sh"
+release_test_reproducibility="$release_test_script_dir/verify-reproducible-release.sh"
+release_test_publish_workflow="$release_test_project_dir/.github/workflows/publish-central.yml"
+release_test_ci_workflow="$release_test_project_dir/.github/workflows/ci.yml"
+release_test_contributing="$release_test_project_dir/CONTRIBUTING.md"
+release_test_publishing_docs="$release_test_project_dir/docs/publishing.md"
+release_test_reproducible_pom="$release_test_project_dir/src/test/release-tooling/reproducible-release-pom.xml"
+
+release_test_usage() {
+  echo "Usage: $0 development | stable-tag <vMAJOR.MINOR.PATCH>" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  release_test_usage
+  exit 2
+fi
+
+release_test_mode=$1
+release_test_release_tag=
+case "$release_test_mode" in
+  development)
+    if [[ $# -ne 1 ]]; then
+      release_test_usage
+      exit 2
+    fi
+    ;;
+  stable-tag)
+    if [[ $# -ne 2 ]]; then
+      release_test_usage
+      exit 2
+    fi
+    release_test_release_tag=$2
+    if [[ ! "$release_test_release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+      echo "Stable release tooling mode requires an exact vMAJOR.MINOR.PATCH tag: $release_test_release_tag" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    release_test_usage
+    exit 2
+    ;;
+esac
+
+release_test_output_file=$(mktemp)
+release_test_tmp_dir=$(mktemp -d)
+release_test_gnupg_home=
+
+release_test_report_failure() {
+  local release_test_failure_status=$?
+  echo "Release tooling tests failed at line ${BASH_LINENO[0]} (exit $release_test_failure_status)." >&2
+  return "$release_test_failure_status"
+}
+
+release_test_cleanup() {
+  local release_test_cleanup_status=$?
+  trap - ERR EXIT
+  if [[ -n "$release_test_gnupg_home" && -d "$release_test_gnupg_home" ]]; then
+    GNUPGHOME="$release_test_gnupg_home" gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+  fi
+  rm -f "$release_test_output_file"
+  rm -rf "$release_test_tmp_dir"
+  exit "$release_test_cleanup_status"
+}
+
+trap release_test_report_failure ERR
+trap release_test_cleanup EXIT
+
+release_test_commit=0123456789abcdef0123456789abcdef01234567
+
+"$release_test_bundle_membership" >"$release_test_output_file"
+grep -Fq 'Release-bundle membership validation passed without a pipefail/SIGPIPE false negative.' \
+  "$release_test_output_file"
+
+if grep -Eq 'unzip.*-Z1.*\|.*grep' "$release_test_bundle_validator"; then
+  echo "Release bundle membership checks must never pipe archive listing into grep -q under pipefail." >&2
+  exit 1
+fi
+
+release_test_fake_git="$release_test_tmp_dir/fake-git"
+release_test_git_log="$release_test_tmp_dir/git.log"
+cat >"$release_test_fake_git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_GIT_LOG"
+exit "$FAKE_GIT_ANCESTRY_STATUS"
+EOF
+chmod +x "$release_test_fake_git"
+
+if ! GIT_BIN="$release_test_fake_git" FAKE_GIT_LOG="$release_test_git_log" \
+    FAKE_GIT_ANCESTRY_STATUS=0 "$release_test_main_guard" "$release_test_commit" \
+    >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected the release-main guard to accept a commit reachable from origin/main." >&2
+  exit 1
+fi
+
+grep -Fxq "merge-base --is-ancestor $release_test_commit origin/main" "$release_test_git_log"
+
+if GIT_BIN="$release_test_fake_git" FAKE_GIT_LOG="$release_test_git_log" \
+    FAKE_GIT_ANCESTRY_STATUS=1 "$release_test_main_guard" "$release_test_commit" \
+    >"$release_test_output_file" 2>&1; then
+  echo "Expected the release-main guard to reject a commit outside origin/main." >&2
+  exit 1
+fi
+
+grep -Fq "Release commit $release_test_commit is not reachable from origin/main." \
+  "$release_test_output_file"
+
+if GIT_BIN="$release_test_fake_git" FAKE_GIT_LOG="$release_test_git_log" \
+    FAKE_GIT_ANCESTRY_STATUS=128 "$release_test_main_guard" "$release_test_commit" \
+    >"$release_test_output_file" 2>&1; then
+  echo "Expected the release-main guard to fail closed when ancestry cannot be proved." >&2
+  exit 1
+fi
+
+grep -Fq "Could not prove that release commit $release_test_commit is reachable from origin/main." \
+  "$release_test_output_file"
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1-SNAPSHOT \
+    "$release_test_tmp_dir/nonexistent-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject a non-stable version." >&2
+  exit 1
+fi
+
+grep -Fq 'Release bundle version must use the exact stable form MAJOR.MINOR.PATCH: 0.2.1-SNAPSHOT' \
+  "$release_test_output_file"
+
+if CENTRAL_READBACK_TIMEOUT_SECONDS=0 "$release_test_central_readback" 0.2.1 \
+    >"$release_test_output_file" 2>&1; then
+  echo "Expected Central readback to reject an unbounded zero-second shared timeout." >&2
+  exit 1
+fi
+
+grep -Fq 'CENTRAL_READBACK_TIMEOUT_SECONDS must be a positive integer.' \
+  "$release_test_output_file"
+
+if CENTRAL_SMOKE_REQUEST_TIMEOUT_SECONDS=0 "$release_test_central_smoke" 0.2.1 \
+    >"$release_test_output_file" 2>&1; then
+  echo "Expected the Central consumer probe to reject an unbounded request timeout." >&2
+  exit 1
+fi
+
+grep -Fq 'CENTRAL_SMOKE_REQUEST_TIMEOUT_SECONDS must be a positive integer.' \
+  "$release_test_output_file"
+
+if ! "$release_test_guard" v0.2.1 "$release_test_fixture_pom" >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected the release tag guard to accept an exact tag, Maven version, and SCM tag." >&2
+  exit 1
+fi
+
+if "$release_test_guard" v0.2.2 "$release_test_fixture_pom" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release tag guard to reject a tag that differs from the Maven version." >&2
+  exit 1
+fi
+
+grep -Fq 'Release tag v0.2.2 does not match Maven version 0.2.1.' "$release_test_output_file"
+
+if "$release_test_guard" v0.2.1 "$release_test_wrong_scm_pom" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release tag guard to reject a different Maven SCM tag." >&2
+  exit 1
+fi
+
+grep -Fq 'Maven SCM tag HEAD does not match release tag v0.2.1.' "$release_test_output_file"
+
+if "$release_test_guard" v0.2.1 "$release_test_snapshot_pom" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release tag guard to reject a snapshot Maven version." >&2
+  exit 1
+fi
+
+grep -Fq 'Maven Central releases cannot use a SNAPSHOT version: 0.2.1-SNAPSHOT.' "$release_test_output_file"
+
+release_test_project_version=$("$release_test_project_dir/mvnw" --quiet --no-transfer-progress \
+  -f "$release_test_project_dir/pom.xml" help:evaluate -Dexpression=project.version -DforceStdout)
+release_test_project_scm_tag=$("$release_test_project_dir/mvnw" --quiet --no-transfer-progress \
+  -f "$release_test_project_dir/pom.xml" help:evaluate -Dexpression=project.scm.tag -DforceStdout)
+
+case "$release_test_mode" in
+  development)
+    if [[ ! "$release_test_project_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-SNAPSHOT$ ]]; then
+      echo "Development release-tooling mode requires a MAJOR.MINOR.PATCH-SNAPSHOT Maven version, found $release_test_project_version." >&2
+      exit 1
+    fi
+
+    if [[ "$release_test_project_scm_tag" != HEAD ]]; then
+      echo "Development release-tooling mode requires Maven SCM tag HEAD, found $release_test_project_scm_tag." >&2
+      exit 1
+    fi
+
+    if "$release_test_project_dir/mvnw" --batch-mode --no-transfer-progress \
+        -f "$release_test_project_dir/pom.xml" -Prelease validate \
+        >"$release_test_output_file" 2>&1; then
+      echo "Expected the release Maven profile to reject a SNAPSHOT project version." >&2
+      exit 1
+    fi
+
+    grep -Fq 'The release profile cannot publish a SNAPSHOT project version.' \
+      "$release_test_output_file"
+    ;;
+  stable-tag)
+    if ! "$release_test_guard" "$release_test_release_tag" "$release_test_project_dir/pom.xml" \
+        >"$release_test_output_file" 2>&1; then
+      cat "$release_test_output_file" >&2
+      echo "Stable release-tooling mode requires matching tag, Maven version, and SCM tag." >&2
+      exit 1
+    fi
+
+    if ! "$release_test_project_dir/mvnw" --batch-mode --no-transfer-progress \
+        -f "$release_test_project_dir/pom.xml" -Prelease validate \
+        >"$release_test_output_file" 2>&1; then
+      cat "$release_test_output_file" >&2
+      echo "Expected the release Maven profile to accept stable release metadata." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+release_test_effective_pom="$release_test_tmp_dir/effective-release-pom.xml"
+"$release_test_project_dir/mvnw" --quiet --no-transfer-progress -f "$release_test_project_dir/pom.xml" \
+  -Prelease help:effective-pom -Doutput="$release_test_effective_pom"
+release_test_default_skip_publishing=$("$release_test_project_dir/mvnw" --quiet \
+  --no-transfer-progress -f "$release_test_project_dir/pom.xml" \
+  help:evaluate -Dexpression=central.skipPublishing -DforceStdout)
+
+if [[ "$release_test_default_skip_publishing" != true ]]; then
+  echo "central.skipPublishing must default to true; publishing requires an explicit protected-workflow override." >&2
+  exit 1
+fi
+
+for release_test_required_profile_fragment in \
+    '<artifactId>maven-source-plugin</artifactId>' '<version>3.4.0</version>' \
+    '<artifactId>maven-javadoc-plugin</artifactId>' '<version>3.12.0</version>' \
+    '<artifactId>maven-gpg-plugin</artifactId>' '<version>3.2.8</version>' \
+    '<bestPractices>true</bestPractices>' '<arg>--pinentry-mode</arg>' '<arg>loopback</arg>' \
+    '<id>enforce-release-version</id>' '<requireReleaseVersion>' \
+    '<artifactId>maven-deploy-plugin</artifactId>' '<version>3.1.4</version>' \
+    '<artifactId>central-publishing-maven-plugin</artifactId>' '<version>0.11.0</version>' \
+    '<extensions>true</extensions>' '<publishingServerId>central</publishingServerId>' \
+    '<autoPublish>true</autoPublish>' '<waitUntil>published</waitUntil>' \
+    '<waitMaxTime>7200</waitMaxTime>' '<waitPollingInterval>10</waitPollingInterval>' \
+    '<checksums>all</checksums>' '<ignorePublishedComponents>false</ignorePublishedComponents>' \
+    '<skipPublishing>true</skipPublishing>'; do
+  if ! grep -Fq "$release_test_required_profile_fragment" "$release_test_effective_pom"; then
+    echo "Release Maven profile is missing: $release_test_required_profile_fragment" >&2
+    exit 1
+  fi
+done
+
+if [[ $(grep -Fc 'central.skipPublishing=false' "$release_test_publish_workflow") -ne 1 ]]; then
+  echo "Only one explicit publishing override is allowed in the protected Maven Central workflow." >&2
+  exit 1
+fi
+
+for release_test_safe_default_file in \
+    "$release_test_project_dir/pom.xml" \
+    "$release_test_project_dir/README.md" \
+    "$release_test_project_dir/CONTRIBUTING.md" \
+    "$release_test_project_dir/CHANGELOG.md" \
+    "$release_test_project_dir/docs"/*.md \
+    "$release_test_project_dir/scripts"/*.sh \
+    "$release_test_project_dir/.github/workflows"/*.yml; do
+  if [[ "$release_test_safe_default_file" == "$release_test_publish_workflow" \
+      || "$release_test_safe_default_file" == "$release_test_project_dir/scripts/test-release-tooling.sh" ]]; then
+    continue
+  fi
+  if grep -Fq 'central.skipPublishing=false' "$release_test_safe_default_file"; then
+    echo "Publishing override escaped the protected workflow: $release_test_safe_default_file" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '^[[:space:]]+gpg-(private-key|passphrase):' "$release_test_publish_workflow"; then
+  echo "The Maven Central workflow must pass signing secrets only through the publication step environment." >&2
+  exit 1
+fi
+
+if [[ ! -s "$release_test_publish_workflow" ]]; then
+  echo "Expected a Maven Central publication workflow at $release_test_publish_workflow." >&2
+  exit 1
+fi
+
+if grep -Eq '^[[:space:]]*(pull_request|pull_request_target|schedule|workflow_dispatch):' "$release_test_publish_workflow"; then
+  echo "The Maven Central publication workflow must be tag-push-only." >&2
+  exit 1
+fi
+
+for release_test_required_workflow_fragment in \
+    'tags:' '- "v*.*.*"' 'contents: read' 'persist-credentials: false' 'fetch-depth: 0' \
+    'name: maven-central' 'id-token: write' 'attestations: write' \
+    'artifact-metadata: write' './scripts/validate-release-tag.sh' \
+    './scripts/assert-release-commit-on-main.sh' './scripts/verify-reproducible-release.sh' \
+    './scripts/assert-central-version-new.sh' 'central.skipPublishing=false' \
+    './scripts/validate-release-bundle.sh' \
+    'run: ./scripts/verify-central-publication.sh "${{ steps.release.outputs.version }}" "${{ github.workspace }}/target/central-publishing/central-bundle.zip" "${{ github.workspace }}"' \
+    './scripts/central-consumer-smoke-test.sh' 'secrets.MAVEN_CENTRAL_USERNAME' \
+    'CENTRAL_READBACK_MAX_ATTEMPTS: "80"' 'CENTRAL_READBACK_RETRY_SECONDS: "15"' \
+    'CENTRAL_READBACK_TIMEOUT_SECONDS: "1200"' \
+    'CENTRAL_READBACK_REQUEST_TIMEOUT_SECONDS: "10"' \
+    'CENTRAL_SMOKE_MAX_ATTEMPTS: "24"' 'CENTRAL_SMOKE_RETRY_SECONDS: "15"' \
+    'CENTRAL_SMOKE_REQUEST_TIMEOUT_SECONDS: "10"' \
+    'secrets.MAVEN_CENTRAL_TOKEN' 'secrets.MAVEN_GPG_PRIVATE_KEY' \
+    'secrets.MAVEN_GPG_PASSPHRASE' 'gpg --batch --quiet --import' \
+    'unset MAVEN_GPG_PRIVATE_KEY' 'release-public-key.gpg' \
+    'release-verification-gnupg'; do
+  if ! grep -Fq -- "$release_test_required_workflow_fragment" "$release_test_publish_workflow"; then
+    echo "Maven Central publication workflow is missing: $release_test_required_workflow_fragment" >&2
+    exit 1
+  fi
+done
+
+if [[ $(grep -Fxc '    timeout-minutes: 180' "$release_test_publish_workflow") -ne 1 ]]; then
+  echo "The protected publication job must have one 180-minute bounded timeout." >&2
+  exit 1
+fi
+
+if (( 7200 + 1200 + 10 + (24 * (15 + 10)) >= 180 * 60 )); then
+  echo "Configured Central wait/retry limits must fit inside the protected publication timeout." >&2
+  exit 1
+fi
+
+release_test_workflow_line() {
+  local release_test_workflow_fragment=$1
+  local release_test_match
+  local release_test_line
+  if ! release_test_match=$(grep -m 1 -n -F -- "$release_test_workflow_fragment" \
+      "$release_test_publish_workflow"); then
+    echo "Maven Central publication workflow is missing ordered step: $release_test_workflow_fragment" >&2
+    exit 1
+  fi
+  release_test_line=${release_test_match%%:*}
+  printf '%s\n' "$release_test_line"
+}
+
+release_test_identity_line=$(release_test_workflow_line \
+  'run: ./scripts/validate-release-tag.sh "$GITHUB_REF_NAME"')
+release_test_ancestry_line=$(release_test_workflow_line \
+  'run: ./scripts/assert-release-commit-on-main.sh "$GITHUB_SHA"')
+release_test_stable_mode_line=$(release_test_workflow_line \
+  'run: ./scripts/test-release-tooling.sh stable-tag "$GITHUB_REF_NAME"')
+release_test_build_line=$(release_test_workflow_line \
+  'run: ./mvnw --batch-mode --no-transfer-progress clean verify')
+release_test_smoke_line=$(release_test_workflow_line 'run: ./scripts/smoke-test.sh')
+release_test_reproducibility_line=$(release_test_workflow_line \
+  'run: ./scripts/verify-reproducible-release.sh "$GITHUB_REF_NAME"')
+
+if ! (( release_test_identity_line < release_test_ancestry_line
+    && release_test_ancestry_line < release_test_stable_mode_line
+    && release_test_stable_mode_line < release_test_build_line
+    && release_test_build_line < release_test_smoke_line
+    && release_test_smoke_line < release_test_reproducibility_line )); then
+  echo "The tag workflow must validate identity and main ancestry, run stable-tag tooling, then build, smoke-test, and verify reproducibility in that order." >&2
+  exit 1
+fi
+
+for release_test_required_ci_fragment in \
+    './scripts/test-release-tooling.sh development' \
+    './scripts/test-release-tooling.sh stable-tag "v$release_ci_version"'; do
+  if ! grep -Fq -- "$release_test_required_ci_fragment" "$release_test_ci_workflow"; then
+    echo "Ordinary CI is missing release-tooling mode: $release_test_required_ci_fragment" >&2
+    exit 1
+  fi
+done
+
+for release_test_required_contributing_fragment in \
+    './scripts/test-release-tooling.sh development' \
+    './scripts/test-release-tooling.sh stable-tag v0.2.1'; do
+  if ! grep -Fq -- "$release_test_required_contributing_fragment" "$release_test_contributing"; then
+    echo "CONTRIBUTING.md is missing release-tooling guidance: $release_test_required_contributing_fragment" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq './scripts/test-release-tooling.sh stable-tag v0.2.1' \
+    "$release_test_publishing_docs"; then
+  echo "The release runbook must use stable-tag release-tooling mode after preparing stable metadata." >&2
+  exit 1
+fi
+
+for release_test_required_environment_fragment in \
+    'deployment tags restricted to protected release tags matching `v*.*.*`' \
+    'required approval from `Devansh-ops`' \
+    '5-minute wait timer'; do
+  if ! grep -Fq -- "$release_test_required_environment_fragment" \
+      "$release_test_publishing_docs"; then
+    echo "The release runbook is missing the current protected-environment contract: $release_test_required_environment_fragment" >&2
+    exit 1
+  fi
+done
+
+if [[ $(grep -Fxc '          fetch-depth: 0' "$release_test_publish_workflow") -ne 2 ]]; then
+  echo "Both Maven Central jobs must fetch full history before checking origin/main ancestry." >&2
+  exit 1
+fi
+
+if grep -R -Fq 'UPLOAD_DISABLED_LOCAL_VALIDATION' \
+    "$release_test_project_dir/.github" "$release_test_project_dir/docs" \
+    "$release_test_project_dir/README.md" "$release_test_project_dir/CONTRIBUTING.md" \
+    "$release_test_project_dir/CHANGELOG.md"; then
+  echo "Upload-disabled placeholder server values must never appear in workflows or documentation." >&2
+  exit 1
+fi
+
+if grep -E '^[[:space:]]*uses:[[:space:]]+[^@[:space:]]+@(v|main|master|[0-9a-f]{1,39}([^0-9a-f]|$))' \
+    "$release_test_publish_workflow"; then
+  echo "Every third-party action in the Maven Central publication workflow must be pinned to a full commit SHA." >&2
+  exit 1
+fi
+
+release_test_fake_curl="$release_test_tmp_dir/fake-curl"
+release_test_curl_log="$release_test_tmp_dir/curl.log"
+cat >"$release_test_fake_curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_CURL_LOG"
+printf '%s' "$FAKE_CURL_STATUS"
+EOF
+chmod +x "$release_test_fake_curl"
+
+if ! CURL_BIN="$release_test_fake_curl" FAKE_CURL_LOG="$release_test_curl_log" FAKE_CURL_STATUS=404 \
+    "$release_test_central_guard" 0.2.1 "$release_test_fixture_pom" >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected an absent Maven Central coordinate to pass the duplicate-version guard." >&2
+  exit 1
+fi
+
+grep -Fq 'https://repo.maven.apache.org/maven2/io/github/devansh-ops/release-tooling-fixture/0.2.1/release-tooling-fixture-0.2.1.pom' \
+  "$release_test_curl_log"
+
+if CURL_BIN="$release_test_fake_curl" FAKE_CURL_LOG="$release_test_curl_log" FAKE_CURL_STATUS=200 \
+    "$release_test_central_guard" 0.2.1 "$release_test_fixture_pom" >"$release_test_output_file" 2>&1; then
+  echo "Expected an existing Maven Central coordinate to fail the duplicate-version guard." >&2
+  exit 1
+fi
+
+grep -Fq 'Maven Central already contains io.github.devansh-ops:release-tooling-fixture:0.2.1; published versions are immutable.' \
+  "$release_test_output_file"
+
+if CURL_BIN="$release_test_fake_curl" FAKE_CURL_LOG="$release_test_curl_log" FAKE_CURL_STATUS=503 \
+    "$release_test_central_guard" 0.2.1 "$release_test_fixture_pom" >"$release_test_output_file" 2>&1; then
+  echo "Expected an inconclusive Maven Central response to fail closed." >&2
+  exit 1
+fi
+
+grep -Fq 'Could not prove that io.github.devansh-ops:release-tooling-fixture:0.2.1 is unpublished: Maven Central returned HTTP 503.' \
+  "$release_test_output_file"
+
+release_test_fake_maven="$release_test_tmp_dir/fake-maven"
+cat >"$release_test_fake_maven" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+fake_maven_settings=
+fake_maven_local_repository=
+for fake_maven_argument in "$@"; do
+  case "$fake_maven_argument" in
+    --settings=*) fake_maven_settings=${fake_maven_argument#--settings=} ;;
+    -Dmaven.repo.local=*) fake_maven_local_repository=${fake_maven_argument#-Dmaven.repo.local=} ;;
+  esac
+done
+test -n "$fake_maven_settings"
+test -n "$fake_maven_local_repository"
+grep -Fq '<mirrorOf>*</mirrorOf>' "$fake_maven_settings"
+grep -Fq '<url>https://repo.maven.apache.org/maven2</url>' "$fake_maven_settings"
+printf '%s\n' "$*" | grep -Fq -- '-Drewrite.recipeArtifactCoordinates=io.github.devansh-ops:rewrite-spring-to-helidon:0.2.1'
+mkdir -p target/rewrite/datatables/fixture
+mkdir -p "$fake_maven_local_repository/io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1"
+printf '%s\n' 'PARTIAL: Dependency injection -> Jakarta CDI and jakarta.inject' \
+  'MANUAL: Spring Java API [SPRING_JAVA_API]' >target/rewrite/rewrite.patch
+printf '%s\n' 'PARTIAL,Jakarta CDI and jakarta.inject' >target/rewrite/datatables/fixture/SpringUsageTable.csv
+printf '%s\n' 'SPRING_MAVEN_DEPENDENCY' 'SPRING_JAVA_API' >target/rewrite/datatables/fixture/MigrationAssessmentTable.csv
+printf '%s\n' 'published recipe' \
+  >"$fake_maven_local_repository/io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.jar"
+EOF
+chmod +x "$release_test_fake_maven"
+
+if ! CURL_BIN="$release_test_fake_curl" FAKE_CURL_LOG="$release_test_curl_log" FAKE_CURL_STATUS=200 \
+    MAVEN_BIN="$release_test_fake_maven" CENTRAL_SMOKE_MAX_ATTEMPTS=1 CENTRAL_SMOKE_RETRY_SECONDS=0 \
+    "$release_test_central_smoke" 0.2.1 >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected the clean Central-only consumer smoke seam to execute the released recipe." >&2
+  exit 1
+fi
+
+grep -Fq 'Central-only consumer smoke test passed for io.github.devansh-ops:rewrite-spring-to-helidon:0.2.1.' \
+  "$release_test_output_file"
+
+release_test_incomplete_root="$release_test_tmp_dir/incomplete"
+release_test_coordinate_path="io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1"
+mkdir -p "$release_test_incomplete_root/$release_test_coordinate_path"
+printf 'fixture\n' >"$release_test_incomplete_root/$release_test_coordinate_path/README.txt"
+(
+  cd "$release_test_incomplete_root"
+  jar --create --file "$release_test_tmp_dir/incomplete-bundle.zip" .
+)
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/incomplete-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject a bundle missing its main artifact." >&2
+  exit 1
+fi
+
+grep -Fq 'Missing required release bundle entry: io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.jar' \
+  "$release_test_output_file"
+
+release_test_missing_sources_root="$release_test_tmp_dir/missing-sources"
+mkdir -p "$release_test_missing_sources_root/$release_test_coordinate_path"
+printf 'fixture jar\n' >"$release_test_missing_sources_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.jar"
+(
+  cd "$release_test_missing_sources_root"
+  jar --create --file "$release_test_tmp_dir/missing-sources-bundle.zip" .
+)
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/missing-sources-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject a bundle missing its sources artifact." >&2
+  exit 1
+fi
+
+grep -Fq 'Missing required release bundle entry: io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1-sources.jar' \
+  "$release_test_output_file"
+
+release_test_missing_javadoc_root="$release_test_tmp_dir/missing-javadoc"
+mkdir -p "$release_test_missing_javadoc_root/$release_test_coordinate_path"
+printf 'fixture jar\n' >"$release_test_missing_javadoc_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.jar"
+printf 'fixture sources\n' >"$release_test_missing_javadoc_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1-sources.jar"
+(
+  cd "$release_test_missing_javadoc_root"
+  jar --create --file "$release_test_tmp_dir/missing-javadoc-bundle.zip" .
+)
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/missing-javadoc-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject a bundle missing its javadoc artifact." >&2
+  exit 1
+fi
+
+grep -Fq 'Missing required release bundle entry: io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1-javadoc.jar' \
+  "$release_test_output_file"
+
+release_test_missing_pom_root="$release_test_tmp_dir/missing-pom"
+mkdir -p "$release_test_missing_pom_root/$release_test_coordinate_path"
+printf 'fixture jar\n' >"$release_test_missing_pom_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.jar"
+printf 'fixture sources\n' >"$release_test_missing_pom_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1-sources.jar"
+printf 'fixture javadoc\n' >"$release_test_missing_pom_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1-javadoc.jar"
+(
+  cd "$release_test_missing_pom_root"
+  jar --create --file "$release_test_tmp_dir/missing-pom-bundle.zip" .
+)
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/missing-pom-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject a bundle missing its POM." >&2
+  exit 1
+fi
+
+grep -Fq 'Missing required release bundle entry: io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.pom' \
+  "$release_test_output_file"
+
+release_test_unsigned_root="$release_test_tmp_dir/unsigned"
+mkdir -p "$release_test_unsigned_root/$release_test_coordinate_path"
+for release_test_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  printf 'fixture artifact\n' >"$release_test_unsigned_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1$release_test_suffix"
+done
+(
+  cd "$release_test_unsigned_root"
+  jar --create --file "$release_test_tmp_dir/unsigned-bundle.zip" .
+)
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/unsigned-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject unsigned artifacts." >&2
+  exit 1
+fi
+
+grep -Fq 'Missing required release bundle entry: io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.jar.asc' \
+  "$release_test_output_file"
+
+release_test_missing_checksums_root="$release_test_tmp_dir/missing-checksums"
+mkdir -p "$release_test_missing_checksums_root/$release_test_coordinate_path"
+for release_test_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  release_test_artifact="$release_test_missing_checksums_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1$release_test_suffix"
+  printf 'fixture artifact\n' >"$release_test_artifact"
+  printf 'fixture signature\n' >"$release_test_artifact.asc"
+done
+(
+  cd "$release_test_missing_checksums_root"
+  jar --create --file "$release_test_tmp_dir/missing-checksums-bundle.zip" .
+)
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/missing-checksums-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject artifacts without checksums." >&2
+  exit 1
+fi
+
+grep -Fq 'Missing required release bundle entry: io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.jar.md5' \
+  "$release_test_output_file"
+
+release_test_valid_root="$release_test_tmp_dir/valid"
+mkdir -p "$release_test_valid_root/$release_test_coordinate_path"
+for release_test_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  release_test_artifact="$release_test_valid_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1$release_test_suffix"
+  printf 'fixture artifact %s\n' "$release_test_suffix" >"$release_test_artifact"
+  printf 'fixture signature\n' >"$release_test_artifact.asc"
+  md5sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.md5"
+  sha1sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.sha1"
+  sha256sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.sha256"
+  sha512sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.sha512"
+done
+(
+  cd "$release_test_valid_root"
+  jar --create --file "$release_test_tmp_dir/valid-bundle.zip" .
+)
+
+if ! RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/valid-bundle.zip" >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected a structurally complete bundle with valid checksums to pass." >&2
+  exit 1
+fi
+
+printf '0000000000000000000000000000000000000000000000000000000000000000\n' \
+  >"$release_test_valid_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.jar.sha256"
+(
+  cd "$release_test_valid_root"
+  jar --create --file "$release_test_tmp_dir/bad-checksum-bundle.zip" .
+)
+
+if RELEASE_GPG_VERIFY=false "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/bad-checksum-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject a mismatched checksum." >&2
+  exit 1
+fi
+
+grep -Fq 'Checksum mismatch for io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.jar.sha256.' \
+  "$release_test_output_file"
+
+release_test_gnupg_home="$release_test_tmp_dir/gnupg"
+release_test_signed_root="$release_test_tmp_dir/signed"
+release_test_gpg_log="$release_test_tmp_dir/gpg.log"
+mkdir -m 700 "$release_test_gnupg_home"
+mkdir -p "$release_test_signed_root/$release_test_coordinate_path"
+
+release_test_generate_signing_key() {
+  local release_test_gpg_attempt=1
+  local release_test_gpg_max_attempts=3
+  local release_test_gpg_status
+
+  while (( release_test_gpg_attempt <= release_test_gpg_max_attempts )); do
+    if GNUPGHOME="$release_test_gnupg_home" gpg --batch --quiet --pinentry-mode loopback \
+        --passphrase '' --quick-generate-key \
+        'Release tooling test <release-tooling@example.invalid>' rsa2048 sign 1d \
+        >"$release_test_gpg_log" 2>&1; then
+      return 0
+    else
+      release_test_gpg_status=$?
+    fi
+
+    echo "Disposable GPG key generation failed on attempt $release_test_gpg_attempt/$release_test_gpg_max_attempts (exit $release_test_gpg_status)." >&2
+    cat "$release_test_gpg_log" >&2
+    GNUPGHOME="$release_test_gnupg_home" gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+
+    if (( release_test_gpg_attempt == release_test_gpg_max_attempts )); then
+      return "$release_test_gpg_status"
+    fi
+
+    rm -rf "$release_test_gnupg_home"
+    mkdir -m 700 "$release_test_gnupg_home"
+    sleep 1
+    release_test_gpg_attempt=$((release_test_gpg_attempt + 1))
+  done
+}
+
+release_test_sign_artifact() {
+  local release_test_signing_artifact=$1
+  local release_test_signing_status
+
+  if GNUPGHOME="$release_test_gnupg_home" gpg --batch --quiet --yes --armor \
+      --output "$release_test_signing_artifact.asc" --detach-sign \
+      "$release_test_signing_artifact" >"$release_test_gpg_log" 2>&1; then
+    return 0
+  else
+    release_test_signing_status=$?
+  fi
+
+  echo "Disposable GPG signing failed for $release_test_signing_artifact (exit $release_test_signing_status)." >&2
+  cat "$release_test_gpg_log" >&2
+  return "$release_test_signing_status"
+}
+
+release_test_generate_signing_key
+
+for release_test_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  release_test_artifact="$release_test_signed_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1$release_test_suffix"
+  printf 'signed fixture artifact %s\n' "$release_test_suffix" >"$release_test_artifact"
+  release_test_sign_artifact "$release_test_artifact"
+  md5sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.md5"
+  sha1sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.sha1"
+  sha256sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.sha256"
+  sha512sum "$release_test_artifact" | awk '{ print $1 }' >"$release_test_artifact.sha512"
+done
+(
+  cd "$release_test_signed_root"
+  jar --create --file "$release_test_tmp_dir/signed-bundle.zip" .
+)
+
+if ! GNUPGHOME="$release_test_gnupg_home" "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/signed-bundle.zip" >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected a correctly signed bundle to pass cryptographic verification." >&2
+  exit 1
+fi
+
+release_test_expected_project="$release_test_tmp_dir/expected-release-project"
+mkdir -p "$release_test_expected_project/target"
+cp "$release_test_signed_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.jar" \
+  "$release_test_expected_project/target/rewrite-spring-to-helidon-0.2.1.jar"
+cp "$release_test_signed_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1-sources.jar" \
+  "$release_test_expected_project/target/rewrite-spring-to-helidon-0.2.1-sources.jar"
+cp "$release_test_signed_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1-javadoc.jar" \
+  "$release_test_expected_project/target/rewrite-spring-to-helidon-0.2.1-javadoc.jar"
+cp "$release_test_signed_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.pom" \
+  "$release_test_expected_project/pom.xml"
+
+release_test_fake_central_curl="$release_test_tmp_dir/fake-central-curl"
+cat >"$release_test_fake_central_curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+fake_central_output=
+fake_central_url=
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      shift
+      fake_central_output=$1
+      ;;
+    http*)
+      fake_central_url=$1
+      ;;
+  esac
+  shift
+done
+if [[ "$fake_central_output" == /dev/null ]]; then
+  printf '200'
+  exit 0
+fi
+fake_central_relative_path=${fake_central_url#*maven2/}
+cp "$FAKE_CENTRAL_ROOT/$fake_central_relative_path" "$fake_central_output"
+test -s "$fake_central_output"
+EOF
+chmod +x "$release_test_fake_central_curl"
+
+if ! GNUPGHOME="$release_test_gnupg_home" CURL_BIN="$release_test_fake_central_curl" \
+    FAKE_CENTRAL_ROOT="$release_test_signed_root" CENTRAL_READBACK_MAX_ATTEMPTS=1 \
+    CENTRAL_READBACK_RETRY_SECONDS=0 "$release_test_central_readback" 0.2.1 \
+    "$release_test_tmp_dir/signed-bundle.zip" "$release_test_expected_project" \
+    >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected Central readback to validate downloaded artifacts, checksums, and signatures." >&2
+  exit 1
+fi
+
+grep -Fq 'Maven Central readback passed for io.github.devansh-ops:rewrite-spring-to-helidon:0.2.1.' \
+  "$release_test_output_file"
+
+release_test_different_root="$release_test_tmp_dir/different-signed"
+cp -R "$release_test_signed_root" "$release_test_different_root"
+release_test_different_main="$release_test_different_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.jar"
+printf 'different but signed Maven Central artifact\n' >"$release_test_different_main"
+release_test_sign_artifact "$release_test_different_main"
+md5sum "$release_test_different_main" | awk '{ print $1 }' >"$release_test_different_main.md5"
+sha1sum "$release_test_different_main" | awk '{ print $1 }' >"$release_test_different_main.sha1"
+sha256sum "$release_test_different_main" | awk '{ print $1 }' >"$release_test_different_main.sha256"
+sha512sum "$release_test_different_main" | awk '{ print $1 }' >"$release_test_different_main.sha512"
+(
+  cd "$release_test_different_root"
+  jar --create --file "$release_test_tmp_dir/different-signed-bundle.zip" .
+)
+
+if ! GNUPGHOME="$release_test_gnupg_home" "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/different-signed-bundle.zip" >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected the byte-different negative fixture to remain checksum-valid and correctly signed." >&2
+  exit 1
+fi
+
+if GNUPGHOME="$release_test_gnupg_home" CURL_BIN="$release_test_fake_central_curl" \
+    FAKE_CENTRAL_ROOT="$release_test_different_root" CENTRAL_READBACK_MAX_ATTEMPTS=1 \
+    CENTRAL_READBACK_RETRY_SECONDS=0 "$release_test_central_readback" 0.2.1 \
+    "$release_test_tmp_dir/signed-bundle.zip" "$release_test_expected_project" \
+    >"$release_test_output_file" 2>&1; then
+  echo "Expected Central readback to reject different bytes even when their checksums and signature are valid." >&2
+  exit 1
+fi
+
+grep -Fq 'Maven Central bytes differ from submitted bundle: main.jar' \
+  "$release_test_output_file"
+
+release_test_fake_release_maven="$release_test_tmp_dir/fake-release-maven"
+release_test_release_maven_log="$release_test_tmp_dir/release-maven.log"
+release_test_local_release_project="$release_test_tmp_dir/local-release-project"
+mkdir -p "$release_test_local_release_project"
+cp "$release_test_reproducible_pom" "$release_test_local_release_project/pom.xml"
+cat >"$release_test_fake_release_maven" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+fake_release_pom=
+printf '%s\n' "$*" >"$FAKE_RELEASE_MAVEN_LOG"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f)
+      shift
+      fake_release_pom=$1
+      ;;
+  esac
+  shift
+done
+test -n "$fake_release_pom"
+fake_release_project_dir=$(CDPATH= cd -- "$(dirname -- "$fake_release_pom")" && pwd)
+fake_release_prefix="$fake_release_project_dir/target/rewrite-spring-to-helidon-0.2.1"
+mkdir -p "$fake_release_project_dir/target"
+for fake_release_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  fake_release_signature="$fake_release_prefix$fake_release_suffix.asc"
+  if [[ "$fake_release_suffix" == .pom ]]; then
+    fake_release_artifact=$fake_release_pom
+  else
+    fake_release_artifact="$fake_release_prefix$fake_release_suffix"
+    printf 'local structural artifact %s\n' "$fake_release_suffix" >"$fake_release_artifact"
+  fi
+  gpg --batch --quiet --armor --output "$fake_release_signature" \
+    --detach-sign "$fake_release_artifact"
+done
+EOF
+chmod +x "$release_test_fake_release_maven"
+
+if ! GNUPGHOME="$release_test_gnupg_home" MAVEN_BIN="$release_test_fake_release_maven" \
+    FAKE_RELEASE_MAVEN_LOG="$release_test_release_maven_log" \
+    RELEASE_BUNDLE_FILE="$release_test_tmp_dir/local-structural-bundle.zip" \
+    "$release_test_local_bundle_builder" v0.2.1 "$release_test_local_release_project/pom.xml" \
+    >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected local bundle-only release validation to pass for a signed release bundle." >&2
+  exit 1
+fi
+
+grep -Fq -- '-Prelease' "$release_test_release_maven_log"
+grep -Fq -- '-Dcentral.skipPublishing=true' "$release_test_release_maven_log"
+grep -Fq 'clean verify' "$release_test_release_maven_log"
+if grep -Eq '(^|[[:space:]])(deploy|publish)([[:space:]]|$)' "$release_test_release_maven_log"; then
+  echo "Upload-free local bundle validation must not execute a deploy or publish goal." >&2
+  exit 1
+fi
+grep -Fq 'Local structural release-bundle validation passed for v0.2.1.' "$release_test_output_file"
+grep -Fq 'Only the protected publish job validates the Sonatype plugin-produced bundle.' \
+  "$release_test_output_file"
+
+printf 'not a signature\n' \
+  >"$release_test_signed_root/$release_test_coordinate_path/rewrite-spring-to-helidon-0.2.1.jar.asc"
+(
+  cd "$release_test_signed_root"
+  jar --create --file "$release_test_tmp_dir/bad-signature-bundle.zip" .
+)
+
+if GNUPGHOME="$release_test_gnupg_home" "$release_test_bundle_validator" 0.2.1 \
+    "$release_test_tmp_dir/bad-signature-bundle.zip" >"$release_test_output_file" 2>&1; then
+  echo "Expected the release bundle validator to reject an invalid detached signature." >&2
+  exit 1
+fi
+
+grep -Fq 'GPG verification failed for io/github/devansh-ops/rewrite-spring-to-helidon/0.2.1/rewrite-spring-to-helidon-0.2.1.jar.asc.' \
+  "$release_test_output_file"
+
+release_test_fake_reproducible_maven="$release_test_tmp_dir/fake-reproducible-maven"
+release_test_reproducible_maven_log="$release_test_tmp_dir/reproducible-maven.log"
+cat >"$release_test_fake_reproducible_maven" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+fake_reproducible_pom=
+for fake_reproducible_argument_index in "$@"; do
+  printf '%s\n' "$fake_reproducible_argument_index" >>"$FAKE_REPRODUCIBLE_MAVEN_LOG"
+done
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f)
+      shift
+      fake_reproducible_pom=$1
+      ;;
+  esac
+  shift
+done
+
+test -n "$fake_reproducible_pom"
+fake_reproducible_project_dir=$(CDPATH= cd -- "$(dirname -- "$fake_reproducible_pom")" && pwd)
+fake_reproducible_prefix="$fake_reproducible_project_dir/target/rewrite-spring-to-helidon-0.2.1"
+mkdir -p "$fake_reproducible_project_dir/target"
+
+for fake_reproducible_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  fake_reproducible_signature="$fake_reproducible_prefix$fake_reproducible_suffix.asc"
+  if [[ "$fake_reproducible_suffix" == .pom ]]; then
+    fake_reproducible_artifact=$fake_reproducible_pom
+  else
+    fake_reproducible_artifact="$fake_reproducible_prefix$fake_reproducible_suffix"
+    printf 'reproducible artifact %s\n' "$fake_reproducible_suffix" >"$fake_reproducible_artifact"
+  fi
+
+  if [[ "${FAKE_REPRODUCIBLE_DIFFER:-false}" == true \
+      && "$fake_reproducible_project_dir" == */build-2/project/* \
+      && "$fake_reproducible_suffix" == -javadoc.jar ]]; then
+    printf 'non-reproducible second build\n' >>"$fake_reproducible_artifact"
+  fi
+
+  gpg --batch --quiet --armor --output "$fake_reproducible_signature" \
+    --detach-sign "$fake_reproducible_artifact"
+done
+EOF
+chmod +x "$release_test_fake_reproducible_maven"
+
+if ! MAVEN_BIN="$release_test_fake_reproducible_maven" \
+    FAKE_REPRODUCIBLE_MAVEN_LOG="$release_test_reproducible_maven_log" \
+    "$release_test_reproducibility" v0.2.1 "$release_test_reproducible_pom" \
+    >"$release_test_output_file" 2>&1; then
+  cat "$release_test_output_file" >&2
+  echo "Expected two clean release builds with equal primary artifacts to be reproducible." >&2
+  exit 1
+fi
+
+grep -Fq 'Reproducible release artifacts verified for v0.2.1 across two isolated, upload-free builds.' \
+  "$release_test_output_file"
+grep -Fq -- '-Dcentral.skipPublishing=true' "$release_test_reproducible_maven_log"
+if [[ $(grep -Fxc 'clean' "$release_test_reproducible_maven_log") -ne 2 \
+    || $(grep -Fxc 'verify' "$release_test_reproducible_maven_log") -ne 2 ]]; then
+  echo "Expected the reproducibility seam to execute exactly two clean, upload-free verify builds." >&2
+  exit 1
+fi
+if grep -Eq '^(deploy|publish)$' "$release_test_reproducible_maven_log"; then
+  echo "Upload-free reproducibility verification must not execute a deploy or publish goal." >&2
+  exit 1
+fi
+
+if MAVEN_BIN="$release_test_fake_reproducible_maven" \
+    FAKE_REPRODUCIBLE_MAVEN_LOG="$release_test_reproducible_maven_log" \
+    FAKE_REPRODUCIBLE_DIFFER=true \
+    "$release_test_reproducibility" v0.2.1 "$release_test_reproducible_pom" \
+    >"$release_test_output_file" 2>&1; then
+  echo "Expected a byte difference between release artifacts to fail reproducibility verification." >&2
+  exit 1
+fi
+
+grep -Fq 'Release artifact is not reproducible: javadoc.jar' "$release_test_output_file"
+
+echo "Release tooling tests passed."

--- a/scripts/validate-release-bundle.sh
+++ b/scripts/validate-release-bundle.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_bundle_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+release_bundle_project_dir=$(CDPATH= cd -- "$release_bundle_script_dir/.." && pwd)
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <MAJOR.MINOR.PATCH> [central-bundle.zip]" >&2
+  exit 2
+fi
+
+release_bundle_version=$1
+release_bundle_file=${2:-"$release_bundle_project_dir/target/central-publishing/central-bundle.zip"}
+release_bundle_coordinate_path="io/github/devansh-ops/rewrite-spring-to-helidon/$release_bundle_version"
+release_bundle_prefix="$release_bundle_coordinate_path/rewrite-spring-to-helidon-$release_bundle_version"
+release_bundle_gpg_verify=${RELEASE_GPG_VERIFY:-true}
+release_bundle_unzip=${UNZIP_BIN:-unzip}
+
+if [[ ! "$release_bundle_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Release bundle version must use the exact stable form MAJOR.MINOR.PATCH: $release_bundle_version" >&2
+  exit 1
+fi
+
+case "$release_bundle_gpg_verify" in
+  true|false) ;;
+  *)
+    echo "RELEASE_GPG_VERIFY must be true or false." >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -s "$release_bundle_file" ]]; then
+  echo "Release bundle does not exist or is empty: $release_bundle_file" >&2
+  exit 1
+fi
+
+release_bundle_work_dir=$(mktemp -d)
+trap 'rm -rf "$release_bundle_work_dir"' EXIT
+release_bundle_entries_file="$release_bundle_work_dir/archive-entries.txt"
+release_bundle_verify_dir="$release_bundle_work_dir/verified-artifacts"
+mkdir -p "$release_bundle_verify_dir"
+
+if ! "$release_bundle_unzip" -Z1 "$release_bundle_file" >"$release_bundle_entries_file"; then
+  echo "Could not list release bundle entries: $release_bundle_file" >&2
+  exit 1
+fi
+
+release_bundle_require_entry() {
+  local release_bundle_required_entry=$1
+  if ! grep -Fxq -- "$release_bundle_required_entry" "$release_bundle_entries_file"; then
+    echo "Missing required release bundle entry: $release_bundle_required_entry" >&2
+    return 1
+  fi
+}
+
+for release_bundle_primary_entry in \
+    "$release_bundle_prefix.jar" \
+    "$release_bundle_prefix-sources.jar" \
+    "$release_bundle_prefix-javadoc.jar" \
+    "$release_bundle_prefix.pom"; do
+  release_bundle_require_entry "$release_bundle_primary_entry"
+done
+
+for release_bundle_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  release_bundle_signature="$release_bundle_prefix$release_bundle_suffix.asc"
+  release_bundle_require_entry "$release_bundle_signature"
+
+  for release_bundle_checksum_suffix in md5 sha1 sha256 sha512; do
+    release_bundle_checksum="$release_bundle_prefix$release_bundle_suffix.$release_bundle_checksum_suffix"
+    release_bundle_require_entry "$release_bundle_checksum"
+
+    release_bundle_expected_checksum=$("$release_bundle_unzip" -p "$release_bundle_file" "$release_bundle_checksum" | tr -d '[:space:]')
+    case "$release_bundle_checksum_suffix" in
+      md5)
+        release_bundle_actual_checksum=$("$release_bundle_unzip" -p "$release_bundle_file" "$release_bundle_prefix$release_bundle_suffix" | md5sum | awk '{ print $1 }')
+        ;;
+      sha1)
+        release_bundle_actual_checksum=$("$release_bundle_unzip" -p "$release_bundle_file" "$release_bundle_prefix$release_bundle_suffix" | sha1sum | awk '{ print $1 }')
+        ;;
+      sha256)
+        release_bundle_actual_checksum=$("$release_bundle_unzip" -p "$release_bundle_file" "$release_bundle_prefix$release_bundle_suffix" | sha256sum | awk '{ print $1 }')
+        ;;
+      sha512)
+        release_bundle_actual_checksum=$("$release_bundle_unzip" -p "$release_bundle_file" "$release_bundle_prefix$release_bundle_suffix" | sha512sum | awk '{ print $1 }')
+        ;;
+    esac
+
+    if [[ "$release_bundle_expected_checksum" != "$release_bundle_actual_checksum" ]]; then
+      echo "Checksum mismatch for $release_bundle_checksum." >&2
+      exit 1
+    fi
+  done
+
+  if [[ "$release_bundle_gpg_verify" == true ]]; then
+    release_bundle_artifact_file="$release_bundle_verify_dir/artifact$release_bundle_suffix"
+    release_bundle_signature_file="$release_bundle_artifact_file.asc"
+    "$release_bundle_unzip" -p "$release_bundle_file" "$release_bundle_prefix$release_bundle_suffix" >"$release_bundle_artifact_file"
+    "$release_bundle_unzip" -p "$release_bundle_file" "$release_bundle_signature" >"$release_bundle_signature_file"
+    if ! gpg --batch --verify "$release_bundle_signature_file" "$release_bundle_artifact_file" >/dev/null 2>&1; then
+      echo "GPG verification failed for $release_bundle_signature." >&2
+      exit 1
+    fi
+  fi
+done
+
+echo "Release bundle contains the main, sources, javadoc, POM, detached signatures, and checksums for version $release_bundle_version."

--- a/scripts/validate-release-tag.sh
+++ b/scripts/validate-release-tag.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_tag_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+release_tag_project_dir=$(CDPATH= cd -- "$release_tag_script_dir/.." && pwd)
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <vMAJOR.MINOR.PATCH> [pom.xml]" >&2
+  exit 2
+fi
+
+release_tag=$1
+release_tag_pom=${2:-"$release_tag_project_dir/pom.xml"}
+
+if [[ ! "$release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Release tag must use the exact stable form vMAJOR.MINOR.PATCH: $release_tag" >&2
+  exit 1
+fi
+
+release_tag_version=$("$release_tag_project_dir/mvnw" --quiet --no-transfer-progress \
+  -f "$release_tag_pom" help:evaluate -Dexpression=project.version -DforceStdout)
+release_tag_scm=$("$release_tag_project_dir/mvnw" --quiet --no-transfer-progress \
+  -f "$release_tag_pom" help:evaluate -Dexpression=project.scm.tag -DforceStdout)
+
+if [[ "$release_tag_version" == *-SNAPSHOT ]]; then
+  echo "Maven Central releases cannot use a SNAPSHOT version: $release_tag_version." >&2
+  exit 1
+fi
+
+if [[ "$release_tag" != "v$release_tag_version" ]]; then
+  echo "Release tag $release_tag does not match Maven version $release_tag_version." >&2
+  exit 1
+fi
+
+if [[ "$release_tag_scm" != "$release_tag" ]]; then
+  echo "Maven SCM tag $release_tag_scm does not match release tag $release_tag." >&2
+  exit 1
+fi
+
+echo "Release tag $release_tag matches Maven version $release_tag_version and SCM tag."

--- a/scripts/verify-central-publication.sh
+++ b/scripts/verify-central-publication.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+central_readback_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+central_readback_project_dir=$(CDPATH= cd -- "$central_readback_script_dir/.." && pwd)
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  echo "Usage: $0 <MAJOR.MINOR.PATCH> [submitted-central-bundle.zip] [local-project-directory]" >&2
+  exit 2
+fi
+
+central_readback_version=$1
+central_readback_submitted_bundle=${2:-"$central_readback_project_dir/target/central-publishing/central-bundle.zip"}
+central_readback_local_project=${3:-"$central_readback_project_dir"}
+central_readback_repository_url=${CENTRAL_REPOSITORY_URL:-https://repo.maven.apache.org/maven2}
+central_readback_curl=${CURL_BIN:-curl}
+central_readback_max_attempts=${CENTRAL_READBACK_MAX_ATTEMPTS:-120}
+central_readback_retry_seconds=${CENTRAL_READBACK_RETRY_SECONDS:-15}
+central_readback_timeout_seconds=${CENTRAL_READBACK_TIMEOUT_SECONDS:-1800}
+central_readback_request_timeout_seconds=${CENTRAL_READBACK_REQUEST_TIMEOUT_SECONDS:-10}
+
+if [[ ! "$central_readback_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Central readback version must use the exact stable form MAJOR.MINOR.PATCH: $central_readback_version" >&2
+  exit 1
+fi
+
+if [[ ! "$central_readback_max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "CENTRAL_READBACK_MAX_ATTEMPTS must be a positive integer." >&2
+  exit 2
+fi
+
+if [[ ! "$central_readback_retry_seconds" =~ ^[0-9]+$ ]]; then
+  echo "CENTRAL_READBACK_RETRY_SECONDS must be a non-negative integer." >&2
+  exit 2
+fi
+
+if [[ ! "$central_readback_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "CENTRAL_READBACK_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+
+if [[ ! "$central_readback_request_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "CENTRAL_READBACK_REQUEST_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+
+central_readback_coordinate="io.github.devansh-ops:rewrite-spring-to-helidon:$central_readback_version"
+central_readback_coordinate_path="io/github/devansh-ops/rewrite-spring-to-helidon/$central_readback_version"
+central_readback_prefix="$central_readback_coordinate_path/rewrite-spring-to-helidon-$central_readback_version"
+central_readback_pom_url="${central_readback_repository_url%/}/$central_readback_prefix.pom"
+central_readback_deadline=$((SECONDS + central_readback_timeout_seconds))
+
+central_readback_tmp_dir=$(mktemp -d)
+trap 'rm -rf "$central_readback_tmp_dir"' EXIT
+central_readback_expected_dir="$central_readback_tmp_dir/submitted"
+mkdir -p "$central_readback_expected_dir"
+
+"$central_readback_script_dir/validate-release-bundle.sh" \
+  "$central_readback_version" "$central_readback_submitted_bundle"
+
+for central_readback_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  case "$central_readback_suffix" in
+    .jar)
+      central_readback_label=main.jar
+      central_readback_local_file="$central_readback_local_project/target/rewrite-spring-to-helidon-$central_readback_version.jar"
+      ;;
+    -sources.jar)
+      central_readback_label=sources.jar
+      central_readback_local_file="$central_readback_local_project/target/rewrite-spring-to-helidon-$central_readback_version-sources.jar"
+      ;;
+    -javadoc.jar)
+      central_readback_label=javadoc.jar
+      central_readback_local_file="$central_readback_local_project/target/rewrite-spring-to-helidon-$central_readback_version-javadoc.jar"
+      ;;
+    .pom)
+      central_readback_label=pom.xml
+      central_readback_local_file="$central_readback_local_project/pom.xml"
+      ;;
+  esac
+
+  central_readback_submitted_file="$central_readback_expected_dir/$central_readback_label"
+  unzip -p "$central_readback_submitted_bundle" \
+    "$central_readback_prefix$central_readback_suffix" >"$central_readback_submitted_file"
+
+  if [[ ! -f "$central_readback_local_file" ]]; then
+    echo "Local release artifact does not exist: $central_readback_local_file" >&2
+    exit 1
+  fi
+
+  if ! cmp -s "$central_readback_submitted_file" "$central_readback_local_file"; then
+    echo "Submitted bundle bytes differ from local release artifact: $central_readback_label" >&2
+    exit 1
+  fi
+done
+
+central_readback_attempt=1
+while true; do
+  if (( SECONDS >= central_readback_deadline )); then
+    echo "Shared Maven Central readback timeout expired while waiting for $central_readback_coordinate." >&2
+    exit 1
+  fi
+
+  central_readback_http_status=000
+  if central_readback_http_result=$("$central_readback_curl" --silent --show-error --location \
+      --connect-timeout "$central_readback_request_timeout_seconds" \
+      --max-time "$central_readback_request_timeout_seconds" \
+      --output /dev/null --write-out '%{http_code}' "$central_readback_pom_url"); then
+    central_readback_http_status=$central_readback_http_result
+  fi
+
+  if [[ "$central_readback_http_status" == 200 ]]; then
+    break
+  fi
+
+  if (( central_readback_attempt >= central_readback_max_attempts )); then
+    echo "Maven Central did not expose $central_readback_coordinate after $central_readback_attempt attempts; last HTTP status was $central_readback_http_status." >&2
+    exit 1
+  fi
+
+  sleep "$central_readback_retry_seconds"
+  central_readback_attempt=$((central_readback_attempt + 1))
+done
+
+central_readback_root="$central_readback_tmp_dir/repository"
+central_readback_artifact_dir="$central_readback_root/$central_readback_coordinate_path"
+central_readback_bundle="$central_readback_tmp_dir/central-readback-bundle.zip"
+mkdir -p "$central_readback_artifact_dir"
+central_readback_bundle_entries=()
+
+central_readback_download() {
+  local central_readback_relative_path=$1
+  local central_readback_destination="$central_readback_root/$central_readback_relative_path"
+  local central_readback_download_attempt=1
+
+  if (( SECONDS >= central_readback_deadline )); then
+    echo "Shared Maven Central readback timeout expired before downloading $central_readback_relative_path." >&2
+    return 1
+  fi
+
+  while true; do
+    if (( SECONDS >= central_readback_deadline )); then
+      echo "Shared Maven Central readback timeout expired while downloading $central_readback_relative_path." >&2
+      return 1
+    fi
+
+    if "$central_readback_curl" --fail --silent --show-error --location \
+        --connect-timeout "$central_readback_request_timeout_seconds" \
+        --max-time "$central_readback_request_timeout_seconds" \
+        --output "$central_readback_destination" \
+        "${central_readback_repository_url%/}/$central_readback_relative_path"; then
+      break
+    fi
+
+    if (( central_readback_download_attempt >= central_readback_max_attempts )); then
+      echo "Could not download $central_readback_relative_path from Maven Central after $central_readback_download_attempt attempts." >&2
+      return 1
+    fi
+    sleep "$central_readback_retry_seconds"
+    central_readback_download_attempt=$((central_readback_download_attempt + 1))
+  done
+
+  if [[ ! -s "$central_readback_destination" ]]; then
+    echo "Maven Central returned an empty or missing file: $central_readback_relative_path" >&2
+    return 1
+  fi
+  central_readback_bundle_entries+=("$central_readback_relative_path")
+}
+
+for central_readback_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  central_readback_primary="$central_readback_prefix$central_readback_suffix"
+  central_readback_download "$central_readback_primary"
+  central_readback_download "$central_readback_primary.asc"
+  for central_readback_checksum_suffix in md5 sha1 sha256 sha512; do
+    central_readback_download "$central_readback_primary.$central_readback_checksum_suffix"
+  done
+done
+
+if (( ${#central_readback_bundle_entries[@]} != 24 )); then
+  echo "Expected 24 nonempty Central readback files, found ${#central_readback_bundle_entries[@]}." >&2
+  exit 1
+fi
+
+(
+  cd "$central_readback_root"
+  jar --create --file "$central_readback_bundle" "${central_readback_bundle_entries[@]}"
+)
+
+if ! "$central_readback_script_dir/validate-release-bundle.sh" \
+    "$central_readback_version" "$central_readback_bundle"; then
+  echo "Downloaded Central bundle entries were:" >&2
+  jar --list --file "$central_readback_bundle" >&2 || true
+  exit 1
+fi
+
+for central_readback_suffix in .jar -sources.jar -javadoc.jar .pom; do
+  case "$central_readback_suffix" in
+    .jar) central_readback_label=main.jar ;;
+    -sources.jar) central_readback_label=sources.jar ;;
+    -javadoc.jar) central_readback_label=javadoc.jar ;;
+    .pom) central_readback_label=pom.xml ;;
+  esac
+  central_readback_downloaded_file="$central_readback_root/$central_readback_prefix$central_readback_suffix"
+  if ! cmp -s "$central_readback_expected_dir/$central_readback_label" \
+      "$central_readback_downloaded_file"; then
+    echo "Maven Central bytes differ from submitted bundle: $central_readback_label" >&2
+    exit 1
+  fi
+  sha256sum "$central_readback_downloaded_file"
+done
+
+echo "Maven Central readback passed for $central_readback_coordinate."

--- a/scripts/verify-reproducible-release.sh
+++ b/scripts/verify-reproducible-release.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+reproducible_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+reproducible_project_dir=$(CDPATH= cd -- "$reproducible_script_dir/.." && pwd)
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <vMAJOR.MINOR.PATCH> [pom.xml]" >&2
+  exit 2
+fi
+
+reproducible_tag=$1
+reproducible_source_pom=${2:-"$reproducible_project_dir/pom.xml"}
+reproducible_maven=${MAVEN_BIN:-"$reproducible_project_dir/mvnw"}
+
+if [[ ! -f "$reproducible_source_pom" ]]; then
+  echo "Release POM does not exist: $reproducible_source_pom" >&2
+  exit 1
+fi
+
+reproducible_source_pom=$(realpath "$reproducible_source_pom")
+case "$reproducible_source_pom" in
+  "$reproducible_project_dir"/*)
+    reproducible_pom_relative=${reproducible_source_pom#"$reproducible_project_dir"/}
+    ;;
+  *)
+    echo "Release POM must be inside the project directory: $reproducible_source_pom" >&2
+    exit 1
+    ;;
+esac
+
+"$reproducible_script_dir/validate-release-tag.sh" "$reproducible_tag" "$reproducible_source_pom"
+reproducible_version=${reproducible_tag#v}
+reproducible_coordinate_path="io/github/devansh-ops/rewrite-spring-to-helidon/$reproducible_version"
+reproducible_prefix="$reproducible_coordinate_path/rewrite-spring-to-helidon-$reproducible_version"
+
+for reproducible_required_command in tar unzip cmp gpg gpgconf sha256sum; do
+  if ! command -v "$reproducible_required_command" >/dev/null 2>&1; then
+    echo "Reproducibility verification requires $reproducible_required_command." >&2
+    exit 2
+  fi
+done
+
+reproducible_tmp_dir=$(mktemp -d)
+reproducible_gpg_homes=()
+reproducible_cleanup() {
+  local reproducible_gpg_home
+  for reproducible_gpg_home in "${reproducible_gpg_homes[@]}"; do
+    if [[ -d "$reproducible_gpg_home" ]]; then
+      GNUPGHOME="$reproducible_gpg_home" gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+    fi
+  done
+  rm -rf "$reproducible_tmp_dir"
+}
+trap reproducible_cleanup EXIT
+
+reproducible_artifact_names=(main.jar sources.jar javadoc.jar published.pom)
+reproducible_artifact_suffixes=(.jar -sources.jar -javadoc.jar .pom)
+
+for reproducible_build_number in 1 2; do
+  reproducible_build_root="$reproducible_tmp_dir/build-$reproducible_build_number"
+  reproducible_build_project="$reproducible_build_root/project"
+  reproducible_build_home="$reproducible_build_root/home"
+  reproducible_build_maven_home="$reproducible_build_root/maven-user-home"
+  reproducible_build_repository="$reproducible_build_root/maven-repository"
+  reproducible_build_gpg_home="$reproducible_build_root/gnupg"
+  reproducible_build_compare="$reproducible_build_root/primary-artifacts"
+  reproducible_gpg_homes+=("$reproducible_build_gpg_home")
+
+  mkdir -p "$reproducible_build_project" "$reproducible_build_home" \
+    "$reproducible_build_maven_home" "$reproducible_build_repository" \
+    "$reproducible_build_compare"
+  mkdir -m 700 "$reproducible_build_gpg_home"
+
+  tar -C "$reproducible_project_dir" \
+    --exclude=.git --exclude=.codex --exclude=target --exclude='*/target' \
+    -cf - . | tar -C "$reproducible_build_project" -xf -
+
+  reproducible_build_pom="$reproducible_build_project/$reproducible_pom_relative"
+  reproducible_build_bundle="$(dirname -- "$reproducible_build_pom")/target/release-validation/central-layout-test-bundle.zip"
+
+  GNUPGHOME="$reproducible_build_gpg_home" gpg --batch --quiet \
+    --pinentry-mode loopback --passphrase '' \
+    --quick-generate-key \
+    "Reproducibility build $reproducible_build_number <reproducible-$reproducible_build_number@example.invalid>" \
+    rsa2048 sign 1d
+
+  HOME="$reproducible_build_home" \
+    MAVEN_USER_HOME="$reproducible_build_maven_home" \
+    GNUPGHOME="$reproducible_build_gpg_home" \
+    MAVEN_GPG_PASSPHRASE='' \
+    "$reproducible_maven" --batch-mode --no-transfer-progress \
+    -f "$reproducible_build_pom" \
+    -Duser.home="$reproducible_build_home" \
+    -Dmaven.repo.local="$reproducible_build_repository" \
+    -Prelease -Dcentral.skipPublishing=true -DskipTests clean verify
+
+  "$reproducible_build_project/scripts/assemble-central-layout-test-bundle.sh" \
+    "$reproducible_version" "$reproducible_build_pom" "$reproducible_build_bundle"
+
+  GNUPGHOME="$reproducible_build_gpg_home" \
+    "$reproducible_build_project/scripts/validate-release-bundle.sh" \
+    "$reproducible_version" "$reproducible_build_bundle"
+
+  for reproducible_artifact_index in "${!reproducible_artifact_names[@]}"; do
+    reproducible_artifact_name=${reproducible_artifact_names[$reproducible_artifact_index]}
+    reproducible_artifact_suffix=${reproducible_artifact_suffixes[$reproducible_artifact_index]}
+    unzip -p "$reproducible_build_bundle" \
+      "$reproducible_prefix$reproducible_artifact_suffix" \
+      >"$reproducible_build_compare/$reproducible_artifact_name"
+    if [[ ! -s "$reproducible_build_compare/$reproducible_artifact_name" ]]; then
+      echo "Could not extract release artifact for reproducibility comparison: $reproducible_artifact_name" >&2
+      exit 1
+    fi
+  done
+done
+
+for reproducible_artifact_name in "${reproducible_artifact_names[@]}"; do
+  reproducible_first="$reproducible_tmp_dir/build-1/primary-artifacts/$reproducible_artifact_name"
+  reproducible_second="$reproducible_tmp_dir/build-2/primary-artifacts/$reproducible_artifact_name"
+  if ! cmp -s "$reproducible_first" "$reproducible_second"; then
+    echo "Release artifact is not reproducible: $reproducible_artifact_name" >&2
+    sha256sum "$reproducible_first" "$reproducible_second" >&2
+    exit 1
+  fi
+  reproducible_digest=$(sha256sum "$reproducible_first" | awk '{ print $1 }')
+  printf '%s  %s\n' "$reproducible_digest" "$reproducible_artifact_name"
+done
+
+echo "Reproducible release artifacts verified for $reproducible_tag across two isolated, upload-free builds."

--- a/src/test/release-tooling/release-pom.xml
+++ b/src/test/release-tooling/release-pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.devansh-ops</groupId>
+    <artifactId>release-tooling-fixture</artifactId>
+    <version>0.2.1</version>
+    <scm>
+        <connection>scm:git:https://github.com/Devansh-ops/rewrite-spring-to-helidon.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/Devansh-ops/rewrite-spring-to-helidon.git</developerConnection>
+        <url>https://github.com/Devansh-ops/rewrite-spring-to-helidon</url>
+        <tag>v0.2.1</tag>
+    </scm>
+</project>

--- a/src/test/release-tooling/reproducible-release-pom.xml
+++ b/src/test/release-tooling/reproducible-release-pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.devansh-ops</groupId>
+    <artifactId>rewrite-spring-to-helidon</artifactId>
+    <version>0.2.1</version>
+    <scm>
+        <connection>scm:git:https://github.com/Devansh-ops/rewrite-spring-to-helidon.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/Devansh-ops/rewrite-spring-to-helidon.git</developerConnection>
+        <url>https://github.com/Devansh-ops/rewrite-spring-to-helidon</url>
+        <tag>v0.2.1</tag>
+    </scm>
+</project>

--- a/src/test/release-tooling/snapshot-pom.xml
+++ b/src/test/release-tooling/snapshot-pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.devansh-ops</groupId>
+    <artifactId>release-tooling-fixture</artifactId>
+    <version>0.2.1-SNAPSHOT</version>
+    <scm>
+        <connection>scm:git:https://github.com/Devansh-ops/rewrite-spring-to-helidon.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/Devansh-ops/rewrite-spring-to-helidon.git</developerConnection>
+        <url>https://github.com/Devansh-ops/rewrite-spring-to-helidon</url>
+        <tag>v0.2.1</tag>
+    </scm>
+</project>

--- a/src/test/release-tooling/wrong-scm-tag-pom.xml
+++ b/src/test/release-tooling/wrong-scm-tag-pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.devansh-ops</groupId>
+    <artifactId>release-tooling-fixture</artifactId>
+    <version>0.2.1</version>
+    <scm>
+        <connection>scm:git:https://github.com/Devansh-ops/rewrite-spring-to-helidon.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/Devansh-ops/rewrite-spring-to-helidon.git</developerConnection>
+        <url>https://github.com/Devansh-ops/rewrite-spring-to-helidon</url>
+        <tag>HEAD</tag>
+    </scm>
+</project>


### PR DESCRIPTION
## Summary

- add a protected, tag-only Maven Central publication workflow
- build, sign, checksum, attest, and byte-verify main, sources, Javadoc, and POM artifacts
- add deterministic version/tag/ancestry and duplicate-version guards
- add isolated reproducibility, Central-only consumer, release tooling, and readback checks
- document the human namespace, token, signing-key, environment, and immutable-publication gates

This PR prepares the repository for Central publication but does not publish anything. Issue #69 remains open until the protected environment is configured and a reviewed stable tag is published and read back.

## Validation

- `./scripts/test-release-tooling.sh development`
- isolated `stable-tag v0.2.1` release-tooling run
- `./mvnw --batch-mode --no-transfer-progress clean verify` — 171/171 tests
- `./scripts/smoke-test.sh`
- two isolated stable builds produced byte-identical main, sources, Javadoc, and POM artifacts
- signed structural bundle checksum/GPG validation
- independent adversarial review: pass
- two-axis review: Standards pass; Spec pass

Refs #69
