### PR TITLE
Add module-atomic migration readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,26 @@ All notable changes will be documented here. This project follows
   unsigned main, sources, Javadoc, and published POM artifacts.
 - Explicit development and stable-tag release-tooling contracts, exercised in ordinary CI with
   publishing disabled unless the protected release workflow opts in.
+- A separately activatable `AssessSpringBootModuleMigrationReadiness` recipe now exports
+  occurrence-preserving module eligibility/refusal evidence for the
+  `HELIDON_MP_CONSERVATIVE` profile without changing source semantics.
+- A package-private module-atomic coordination seam freezes evidence claims, replacements, and
+  generated paths, validates the complete projected module, and commits all-or-nothing per module
+  while preserving sibling isolation.
 
 ### Changed
 
 - Development metadata now uses `0.2.1-SNAPSHOT` and SCM tag `HEAD`. Version `0.2.0` remains a
   source-only GitHub release and is not represented as a Maven Central publication.
+
+### Safety
+
+- Module readiness fails closed for incomplete or ambiguous Maven/Gradle topology, unparsed known
+  artifacts, unsupported source languages, missing attribution, unresolved build declarations,
+  application configuration, Spring XML/metadata, and remaining Spring source/build evidence.
+- Refused modules receive one sanitized anchor marker; exact blocker rows omit configuration
+  values. Duplicate claims, unclaimed removal, ineffective replacements, and generated-path
+  collisions cancel the entire module plan.
 
 ## [0.2.0] - 2026-08-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ Keep generated `target/` content out of commits.
 - Give every generated `JavaTemplate` the target API classpath it needs.
 - Keep target build changes additive until source residue, compilation, tests, and runtime behavior
   prove that a dependency can be removed.
+- For a family using the module-atomic coordinator, collect and claim evidence before freeze,
+  replace only the exact collected source, declare every generated path, and keep apply
+  decision-free. Tests must prove whole-module cancellation, projected-state residue detection,
+  path/claim conflicts, and sibling isolation.
 - Keep examples generic. Do not submit proprietary source, organization names, credentials, URLs,
   internal package names, or customer data.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ ready to leave Spring.
 | Leaf recipe | Scope |
 | --- | --- |
 | `AddHelidonMpResources` | Opt-in: adds missing CDI and MicroProfile Config scaffolds to executable modules. |
+| `AssessSpringBootModuleMigrationReadiness` | Unreleased, read-only: resolves supplied Maven/Gradle module ownership and reports whether each complete supplied module has any blocker for the `HELIDON_MP_CONSERVATIVE` profile. It does not certify runtime readiness or mutate source. |
 | `FindSpringUsage` | Marks and exports a classified inventory of remaining Spring types. |
 | `FindSpringProjectUsage` | Exports occurrence-level bounded Maven, Gradle, Java source-set, configuration, XML, and Spring registration metadata evidence without changing semantics. |
 | `PrepareMavenBuildForHelidonMp` | Opt-in: adds Helidon dependency management and MP core without removing Spring. |
@@ -413,6 +414,40 @@ The following remain explicit engineering work in v0.2:
 
 The canonical recipe leaves all Spring code in place and adds search markers instead of guessing.
 There is no application-wide atomic runtime switch or Spring-removal finalizer in v0.2.
+
+## Module-atomic readiness assessment in development
+
+The current development source adds a separately activated, no-option recipe:
+
+```text
+io.github.devanshops.rewrite.helidon.AssessSpringBootModuleMigrationReadiness
+```
+
+It builds a module index from the complete set of source files supplied to OpenRewrite. The
+deepest Maven or Gradle build root owns each artifact. Missing or incompatible reactor children,
+ambiguous ownership, unparsed known artifacts, unsupported Kotlin/Groovy application source,
+missing Java attribution, unresolved build declarations, application configuration, Spring XML,
+registration metadata, and remaining Spring source/build evidence all refuse the affected module.
+An `ELIGIBLE_FOR_PROFILE` row means only that no supplied artifact violates the documented
+`HELIDON_MP_CONSERVATIVE` profile. It is not proof that omitted files, runtime-generated behavior,
+infrastructure, packaging, or deployment are ready for Helidon.
+
+Refused modules receive exactly one sanitized marker at a safe module anchor. Every blocker is
+exported separately through `ModuleMigrationReadinessTable`; configuration values and neighboring
+XML or metadata content are never copied into marker text or table cells. Buildless groups that
+have no safe anchor remain table-only.
+
+The package-private coordinator behind this assessment is the atomic seam for future bounded
+migration families. Families must claim exact evidence occurrences, propose replacements for the
+exact collected source, and declare generated paths before the plan freezes. The coordinator then
+re-scans the projected module. Duplicate claims, unclaimed removals, remaining or newly introduced
+residue, invalid replacements, generated-path collisions, or any other refusal discard every
+planned change for that module while leaving eligible siblings independent. The apply phase only
+reads the frozen plan; it makes no new decisions.
+
+This recipe is intentionally absent from the v0.2 canonical top-level recipes. The readiness
+assessment is read-only, and the module-atomic MVC, response, launcher, and finalizer families are
+separate future work.
 
 ## Optional Spring Boot 4 normalization and licensing
 

--- a/docs/automation-boundary.md
+++ b/docs/automation-boundary.md
@@ -34,6 +34,7 @@ preconditions do not prove that the whole module is ready to leave Spring.
 
 | Leaf | v0.2 behavior | Important boundary |
 | --- | --- | --- |
+| `AssessSpringBootModuleMigrationReadiness` | Unreleased read-only module assessment | Resolves supplied Maven/Gradle ownership and exports `ModuleMigrationReadinessTable` rows for the `HELIDON_MP_CONSERVATIVE` profile. Eligibility means only that no supplied artifact produced a profile blocker; it is not runtime certification and the recipe is not in a top-level composition. |
 | `FindSpringUsage` | Assessment | Type-family classification is not occurrence-level proof. Review every marker and row. |
 | `FindSpringProjectUsage` | Assessment | Inventories bounded project evidence without certifying readiness. Gradle detection covers literal plugins-block IDs, literal string coordinates in recognized dependency/BOM calls, and common literal Groovy `group`/`name` map notation; legacy `apply plugin:`, Kotlin named arguments, dynamic expressions, version catalogs, aliases, and unresolved models are not guessed. |
 | `PrepareMavenBuildForHelidonMp` | Opt-in mutation | Additively imports `io.helidon:helidon-dependencies:4.5.3` and adds `helidon-microprofile-core` to detected executable Maven modules. It does not replace parents, remove Spring, change Java, or select feature runtimes. Dependency mediation can still change. |
@@ -50,6 +51,38 @@ preconditions do not prove that the whole module is ready to leave Spring.
 Do not blindly compose mutating leaves. Apply one to an isolated branch or worktree, inspect the
 dry-run patch, compile and test the module, and retain Spring startup until all source, dependency,
 configuration, test, packaging, and deployment contracts have been deliberately migrated.
+
+## Module-atomic readiness profile in development
+
+`AssessSpringBootModuleMigrationReadiness` is a separately activated, no-option, read-only recipe.
+It evaluates the complete `SourceFile` set supplied to OpenRewrite against the stable
+`HELIDON_MP_CONSERVATIVE` profile and reports `ELIGIBLE_FOR_PROFILE` or `REFUSED` per resolved
+module. It does not probe the filesystem for omitted files and does not claim runnable output.
+
+The index assigns each artifact to the deepest compatible Maven or Gradle build root. It refuses
+missing, ambiguous, incomplete, cross-build, or model-disagreeing topology; known artifacts that
+did not parse; unsupported Kotlin/Groovy application sources; incomplete Java attribution;
+unresolved dependency, plugin, or reactor declarations; nonempty `application*` configuration;
+Spring XML and registration metadata; and remaining Spring Java or build evidence. Resolved
+non-Spring Maven declarations remain eligible. Ordinary Gradle `project(...)` dependencies are not
+treated as reactor membership; membership comes from settings declarations.
+
+The public output has two complementary levels:
+
+- exactly one sanitized `MODULE_REFUSED` marker at a safe module anchor; and
+- one occurrence-preserving `ModuleMigrationReadinessTable` row per blocker, with stable reason
+  codes and no configuration values.
+
+The internal coordinator freezes a complete plan in the three-argument `generate` phase. A future
+migration family must claim exact evidence, replace the exact collected source, and declare every
+generated path. Before commit, the coordinator rejects duplicate or unresolved claims, unclaimed
+evidence removal, ineffective claims, fabricated replacements, path collisions, and Spring
+residue introduced or retained by the projected originals or generated sources. Any refusal
+cancels all proposed changes in that module; eligible siblings remain independent. The visitor is
+decision-free and applies only frozen replacements.
+
+This development seam does not yet supply a mutating migration family. MVC, response, launcher,
+packaging, final Spring removal, and runtime validation remain separate bounded work.
 
 ## Bounded transaction migration
 

--- a/src/main/java/io/github/devanshops/rewrite/helidon/AssessSpringBootModuleMigrationReadiness.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/AssessSpringBootModuleMigrationReadiness.java
@@ -1,0 +1,49 @@
+package io.github.devanshops.rewrite.helidon;
+
+import io.github.devanshops.rewrite.helidon.table.ModuleMigrationReadinessTable;
+import org.openrewrite.ExecutionContext;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Read-only, module-atomic eligibility assessment for the conservative Helidon MP profile. */
+public final class AssessSpringBootModuleMigrationReadiness
+        extends ModuleAtomicMigrationRecipe {
+    private static final String REPORTED_ROWS =
+            AssessSpringBootModuleMigrationReadiness.class.getName() + ".reportedRows";
+
+    private transient ModuleMigrationReadinessTable readiness =
+            new ModuleMigrationReadinessTable(this);
+
+    @Override
+    public String getDisplayName() {
+        return "Assess Spring Boot module migration eligibility";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Builds a complete supplied-module index and reports deterministic eligibility " +
+               "or refusal for the conservative Helidon MP migration profile without changing semantics.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(5);
+    }
+
+    @Override
+    protected void reportFrozenPlan(ModuleAtomicMigrationCoordinator coordinator,
+                                    ExecutionContext ctx) {
+        Set<String> reported = ctx.computeMessageIfAbsent(REPORTED_ROWS,
+                key -> ConcurrentHashMap.newKeySet());
+        for (ModuleReadinessDecision decision : coordinator.decisions()) {
+            if (reported.add(decision.rowKey())) {
+                if (readiness == null) {
+                    readiness = new ModuleMigrationReadinessTable(this);
+                }
+                readiness.insertRow(ctx, decision.toRow());
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/devanshops/rewrite/helidon/ModuleAtomicMigrationCoordinator.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/ModuleAtomicMigrationCoordinator.java
@@ -1,0 +1,441 @@
+package io.github.devanshops.rewrite.helidon;
+
+import org.openrewrite.SourceFile;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Collects family claims and candidates, validates a projected module, freezes
+ * complete decisions, then exposes a decision-free apply plan.
+ */
+final class ModuleAtomicMigrationCoordinator {
+    private final ModuleReadinessIndex collectedReadiness = new ModuleReadinessIndex();
+    private final Map<UUID, SourceFile> sourcesById =
+            new LinkedHashMap<UUID, SourceFile>();
+    private final Map<String, SourceFile> sourcesByPath =
+            new LinkedHashMap<String, SourceFile>();
+    private final Map<UUID, List<ReplacementCandidate>> replacementCandidates =
+            new LinkedHashMap<UUID, List<ReplacementCandidate>>();
+    private final Map<String, List<SourceFile>> generationCandidates =
+            new LinkedHashMap<String, List<SourceFile>>();
+    private final Map<UUID, Integer> occurrenceClaims = new HashMap<UUID, Integer>();
+    private final Map<String, Integer> evidenceKeyClaims = new HashMap<String, Integer>();
+    private final List<ModuleReadinessEvidence> collectionProblems =
+            new ArrayList<ModuleReadinessEvidence>();
+    private ModuleReadinessIndex frozenReadiness;
+    private Map<UUID, SourceFile> replacements = Collections.emptyMap();
+    private List<SourceFile> generated = Collections.emptyList();
+    private boolean frozen;
+
+    synchronized void record(SourceFile sourceFile) {
+        requireCollecting();
+        String path = normalize(sourceFile);
+        SourceFile atPath = sourcesByPath.get(path);
+        SourceFile atId = sourcesById.get(sourceFile.getId());
+        if (atPath != null && !atPath.getId().equals(sourceFile.getId())) {
+            collectionProblems.add(planProblem(path, "MODULE_PLAN_CONFLICT",
+                    "More than one supplied source claims the same path"));
+            return;
+        }
+        if (atId != null && !normalize(atId).equals(path)) {
+            collectionProblems.add(planProblem(path, "MODULE_PLAN_CONFLICT",
+                    "One supplied source identity claims conflicting paths"));
+            return;
+        }
+        collectedReadiness.record(sourceFile);
+        sourcesById.put(sourceFile.getId(), sourceFile);
+        sourcesByPath.put(path, sourceFile);
+    }
+
+    ModuleReadinessIndex readinessIndex() {
+        return collectedReadiness;
+    }
+
+    synchronized void claimEvidence(UUID occurrenceId) {
+        requireCollecting();
+        occurrenceClaims.put(occurrenceId,
+                occurrenceClaims.containsKey(occurrenceId) ?
+                        occurrenceClaims.get(occurrenceId) + 1 : 1);
+    }
+
+    synchronized void claimEvidenceKey(String evidenceKey) {
+        requireCollecting();
+        evidenceKeyClaims.put(evidenceKey,
+                evidenceKeyClaims.containsKey(evidenceKey) ?
+                        evidenceKeyClaims.get(evidenceKey) + 1 : 1);
+    }
+
+    synchronized void proposeReplacement(SourceFile before, SourceFile after) {
+        requireCollecting();
+        String beforePath = normalize(before);
+        String afterPath = normalize(after);
+        SourceFile collected = sourcesById.get(before.getId());
+        if (collected != before || sourcesByPath.get(beforePath) != before ||
+                !before.getId().equals(after.getId()) || !beforePath.equals(afterPath)) {
+            addGlobalProblem(collectionProblems, "MODULE_PLAN_CONFLICT",
+                    "A replacement must reference the exact collected source and preserve its ID and path");
+            return;
+        }
+        List<ReplacementCandidate> candidates = replacementCandidates.get(before.getId());
+        if (candidates == null) {
+            candidates = new ArrayList<ReplacementCandidate>();
+            replacementCandidates.put(before.getId(), candidates);
+        }
+        candidates.add(new ReplacementCandidate(beforePath, after));
+    }
+
+    synchronized void proposeGeneration(SourceFile sourceFile) {
+        requireCollecting();
+        String path = normalize(sourceFile);
+        List<SourceFile> candidates = generationCandidates.get(path);
+        if (candidates == null) {
+            candidates = new ArrayList<SourceFile>();
+            generationCandidates.put(path, candidates);
+        }
+        candidates.add(sourceFile);
+    }
+
+    synchronized void freeze(Collection<SourceFile> generatedInThisCycle) {
+        if (frozen) {
+            return;
+        }
+
+        List<ModuleReadinessEvidence> planProblems =
+                new ArrayList<ModuleReadinessEvidence>();
+        planProblems.addAll(collectionProblems);
+        Map<UUID, ReplacementCandidate> selectedReplacements =
+                selectReplacements(planProblems);
+        Map<String, List<SourceFile>> externalGeneratedByPath =
+                new HashMap<String, List<SourceFile>>();
+        for (SourceFile sourceFile : generatedInThisCycle) {
+            String path = normalize(sourceFile);
+            List<SourceFile> atPath = externalGeneratedByPath.get(path);
+            if (atPath == null) {
+                atPath = new ArrayList<SourceFile>();
+                externalGeneratedByPath.put(path, atPath);
+            }
+            atPath.add(sourceFile);
+        }
+        Set<String> externalGeneratedPaths = externalGeneratedByPath.keySet();
+        for (Map.Entry<String, List<SourceFile>> external :
+                externalGeneratedByPath.entrySet()) {
+            if (external.getValue().size() > 1) {
+                planProblems.add(planProblem(external.getKey(),
+                        "MODULE_GENERATED_PATH_COLLISION",
+                        "More than one external generated source claims the same path"));
+            }
+            SourceFile recorded = sourcesByPath.get(external.getKey());
+            if (recorded != null && containsNonEquivalent(
+                    external.getValue(), recorded)) {
+                planProblems.add(planProblem(external.getKey(),
+                        "MODULE_GENERATED_PATH_COLLISION",
+                        "An external generated source collides with a supplied source path"));
+            }
+        }
+        Map<String, SourceFile> selectedGeneration = selectGeneration(
+                externalGeneratedPaths, planProblems);
+
+        Map<String, SourceFile> projected = new LinkedHashMap<String, SourceFile>();
+        for (SourceFile original : ordered(sourcesByPath.values())) {
+            ReplacementCandidate replacement = selectedReplacements.get(original.getId());
+            SourceFile projectedSource = replacement == null ? original : replacement.after;
+            projected.put(normalize(projectedSource), projectedSource);
+        }
+        for (SourceFile sourceFile : ordered(generatedInThisCycle)) {
+            if (!projected.containsKey(normalize(sourceFile))) {
+                projected.put(normalize(sourceFile), sourceFile);
+            }
+        }
+        for (Map.Entry<String, SourceFile> generation : selectedGeneration.entrySet()) {
+            projected.put(generation.getKey(), generation.getValue());
+        }
+
+        ModuleReadinessIndex projectedReadiness = new ModuleReadinessIndex();
+        for (SourceFile sourceFile : ordered(projected.values())) {
+            projectedReadiness.record(sourceFile);
+            ModuleReadinessEvidenceScanner.scanSource(sourceFile, projectedReadiness);
+        }
+        validateEvidenceClaims(selectedReplacements, projectedReadiness, planProblems);
+        for (ModuleReadinessEvidence problem : planProblems) {
+            projectedReadiness.recordEvidence(problem);
+        }
+        projectedReadiness.decisions();
+
+        Map<UUID, SourceFile> committedReplacements = new HashMap<UUID, SourceFile>();
+        for (ReplacementCandidate candidate : orderedReplacements(
+                selectedReplacements.values())) {
+            if (projectedReadiness.isEligibleSourcePath(candidate.path)) {
+                committedReplacements.put(candidate.after.getId(), candidate.after);
+            }
+        }
+        List<SourceFile> committedGenerated = new ArrayList<SourceFile>();
+        List<String> generationPaths = new ArrayList<String>(selectedGeneration.keySet());
+        Collections.sort(generationPaths);
+        for (String path : generationPaths) {
+            if (projectedReadiness.isEligibleSourcePath(path)) {
+                committedGenerated.add(selectedGeneration.get(path));
+            }
+        }
+
+        frozenReadiness = projectedReadiness;
+        replacements = Collections.unmodifiableMap(committedReplacements);
+        generated = Collections.unmodifiableList(committedGenerated);
+        frozen = true;
+    }
+
+    private static boolean containsNonEquivalent(
+            List<SourceFile> sources, SourceFile recorded) {
+        for (SourceFile source : sources) {
+            if (!recorded.getId().equals(source.getId()) ||
+                    !equivalent(recorded, source)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    synchronized List<ModuleReadinessDecision> decisions() {
+        requireFrozen();
+        return frozenReadiness.decisions();
+    }
+
+    synchronized Collection<? extends SourceFile> generatedSources() {
+        requireFrozen();
+        return generated;
+    }
+
+    synchronized SourceFile applyReplacement(SourceFile sourceFile) {
+        requireFrozen();
+        SourceFile replacement = replacements.get(sourceFile.getId());
+        return replacement == null ? sourceFile : replacement;
+    }
+
+    synchronized String markerDescription(UUID id) {
+        requireFrozen();
+        return frozenReadiness.markerDescription(id);
+    }
+
+    private Map<UUID, ReplacementCandidate> selectReplacements(
+            List<ModuleReadinessEvidence> problems) {
+        Map<UUID, ReplacementCandidate> selected =
+                new LinkedHashMap<UUID, ReplacementCandidate>();
+        for (Map.Entry<UUID, List<ReplacementCandidate>> entry :
+                replacementCandidates.entrySet()) {
+            List<ReplacementCandidate> candidates = entry.getValue();
+            if (candidates.size() != 1) {
+                problems.add(planProblem(candidates.get(0).path, "MODULE_PLAN_CONFLICT",
+                        "Multiple replacement candidates claim the same source"));
+            } else {
+                selected.put(entry.getKey(), candidates.get(0));
+            }
+        }
+        return selected;
+    }
+
+    private Map<String, SourceFile> selectGeneration(
+            Set<String> externalGeneratedPaths,
+            List<ModuleReadinessEvidence> problems) {
+        Map<String, SourceFile> selected = new LinkedHashMap<String, SourceFile>();
+        List<String> paths = new ArrayList<String>(generationCandidates.keySet());
+        Collections.sort(paths);
+        for (String path : paths) {
+            List<SourceFile> candidates = generationCandidates.get(path);
+            if (candidates.size() != 1) {
+                problems.add(planProblem(path, "MODULE_PLAN_CONFLICT",
+                        "Multiple generated candidates claim the same path"));
+                continue;
+            }
+            SourceFile existing = sourcesByPath.get(path);
+            if (existing != null && equivalent(existing, candidates.get(0))) {
+                continue;
+            }
+            if (existing != null || externalGeneratedPaths.contains(path)) {
+                problems.add(planProblem(path, "MODULE_GENERATED_PATH_COLLISION",
+                        "A planned generated path is already owned or claimed"));
+                continue;
+            }
+            selected.put(path, candidates.get(0));
+        }
+        return selected;
+    }
+
+    private void validateEvidenceClaims(
+            Map<UUID, ReplacementCandidate> selectedReplacements,
+            ModuleReadinessIndex projectedReadiness,
+            List<ModuleReadinessEvidence> problems) {
+        List<ModuleReadinessEvidence> originals = collectedReadiness.evidenceSnapshot();
+        List<ModuleReadinessEvidence> projected = projectedReadiness.evidenceSnapshot();
+        Map<UUID, List<ModuleReadinessEvidence>> originalById =
+                new HashMap<UUID, List<ModuleReadinessEvidence>>();
+        Map<String, List<ModuleReadinessEvidence>> originalByKey =
+                new HashMap<String, List<ModuleReadinessEvidence>>();
+        Set<UUID> projectedOccurrenceIds = new HashSet<UUID>();
+        for (ModuleReadinessEvidence evidence : originals) {
+            List<ModuleReadinessEvidence> atKey = originalByKey.get(evidence.evidenceKey());
+            if (atKey == null) {
+                atKey = new ArrayList<ModuleReadinessEvidence>();
+                originalByKey.put(evidence.evidenceKey(), atKey);
+            }
+            atKey.add(evidence);
+            if (evidence.markerId != null) {
+                List<ModuleReadinessEvidence> atId = originalById.get(evidence.markerId);
+                if (atId == null) {
+                    atId = new ArrayList<ModuleReadinessEvidence>();
+                    originalById.put(evidence.markerId, atId);
+                }
+                atId.add(evidence);
+            }
+        }
+        for (ModuleReadinessEvidence evidence : projected) {
+            if (evidence.markerId != null) {
+                projectedOccurrenceIds.add(evidence.markerId);
+            }
+        }
+
+        Set<String> claimedOccurrences = new HashSet<String>();
+        for (Map.Entry<UUID, Integer> claim : occurrenceClaims.entrySet()) {
+            List<ModuleReadinessEvidence> matches = originalById.get(claim.getKey());
+            if (claim.getValue() != 1 || matches == null || matches.size() != 1) {
+                addGlobalProblem(problems, "MODULE_PLAN_CONFLICT",
+                        "An occurrence must resolve and be claimed exactly once by one family");
+                continue;
+            }
+            validateClaim(matches.get(0), selectedReplacements, projectedOccurrenceIds,
+                    claimedOccurrences, problems);
+        }
+        for (Map.Entry<String, Integer> claim : evidenceKeyClaims.entrySet()) {
+            List<ModuleReadinessEvidence> matches = originalByKey.get(claim.getKey());
+            if (claim.getValue() != 1 || matches == null || matches.size() != 1) {
+                addGlobalProblem(problems, "MODULE_PLAN_CONFLICT",
+                        "An evidence key must resolve and be claimed exactly once by one family");
+                continue;
+            }
+            ModuleReadinessEvidence match = matches.get(0);
+            if (claimedOccurrences.contains(match.occurrenceKey())) {
+                addGlobalProblem(problems, "MODULE_PLAN_CONFLICT",
+                        "The same evidence was claimed through more than one claim API");
+                continue;
+            }
+            validateClaim(match, selectedReplacements, projectedOccurrenceIds,
+                    claimedOccurrences, problems);
+        }
+
+        Set<String> replacementPaths = new HashSet<String>();
+        for (ReplacementCandidate replacement : selectedReplacements.values()) {
+            replacementPaths.add(replacement.path);
+        }
+        for (ModuleReadinessEvidence original : originals) {
+            if (replacementPaths.contains(original.sourcePath) &&
+                    (original.markerId == null ||
+                            !projectedOccurrenceIds.contains(original.markerId)) &&
+                    !claimedOccurrences.contains(original.occurrenceKey())) {
+                problems.add(planProblem(original.sourcePath,
+                        "MODULE_UNCLAIMED_EVIDENCE_REMOVAL",
+                        "A replacement removed migration evidence it did not explicitly claim"));
+            }
+        }
+    }
+
+    private static void validateClaim(
+            ModuleReadinessEvidence evidence,
+            Map<UUID, ReplacementCandidate> selectedReplacements,
+            Set<UUID> projectedOccurrenceIds,
+            Set<String> claimedOccurrences,
+            List<ModuleReadinessEvidence> problems) {
+        claimedOccurrences.add(evidence.occurrenceKey());
+        boolean hasReplacement = false;
+        for (ReplacementCandidate replacement : selectedReplacements.values()) {
+            if (evidence.sourcePath.equals(replacement.path)) {
+                hasReplacement = true;
+                break;
+            }
+        }
+        if (!hasReplacement) {
+            problems.add(planProblem(evidence.sourcePath, "MODULE_PLAN_CONFLICT",
+                    "Claimed evidence has no replacement in the same source"));
+        } else if (evidence.markerId != null &&
+                projectedOccurrenceIds.contains(evidence.markerId)) {
+            problems.add(planProblem(evidence.sourcePath,
+                    "MODULE_CLAIM_NOT_NEUTRALIZED",
+                    "The projected replacement still contains the claimed evidence"));
+        }
+    }
+
+    private void addGlobalProblem(List<ModuleReadinessEvidence> problems,
+                                  String reasonCode, String reason) {
+        problems.add(planProblem(ModuleReadinessEvidence.ALL_MODULES,
+                reasonCode, reason));
+    }
+
+    private static ModuleReadinessEvidence planProblem(
+            String path, String reasonCode, String reason) {
+        return new ModuleReadinessEvidence(path, "MODULE_PLAN", "Module migration plan",
+                path, reasonCode, reason,
+                "Resolve the family plan conflict before module migration", null, false);
+    }
+
+    private static boolean equivalent(SourceFile left, SourceFile right) {
+        return left.getClass().equals(right.getClass()) &&
+               left.printAll().equals(right.printAll());
+    }
+
+    private static List<SourceFile> ordered(Collection<? extends SourceFile> sources) {
+        List<SourceFile> ordered = new ArrayList<SourceFile>(sources);
+        Collections.sort(ordered, new Comparator<SourceFile>() {
+            @Override
+            public int compare(SourceFile left, SourceFile right) {
+                return normalize(left).compareTo(normalize(right));
+            }
+        });
+        return ordered;
+    }
+
+    private static List<ReplacementCandidate> orderedReplacements(
+            Collection<ReplacementCandidate> candidates) {
+        List<ReplacementCandidate> ordered =
+                new ArrayList<ReplacementCandidate>(candidates);
+        Collections.sort(ordered, new Comparator<ReplacementCandidate>() {
+            @Override
+            public int compare(ReplacementCandidate left, ReplacementCandidate right) {
+                return left.path.compareTo(right.path);
+            }
+        });
+        return ordered;
+    }
+
+    private static String normalize(SourceFile sourceFile) {
+        return ModuleReadinessIndex.normalize(sourceFile.getSourcePath());
+    }
+
+    private void requireCollecting() {
+        if (frozen) {
+            throw new IllegalStateException("The module plan is already frozen");
+        }
+    }
+
+    private void requireFrozen() {
+        if (!frozen) {
+            throw new IllegalStateException("The module plan has not been frozen");
+        }
+    }
+
+    private static final class ReplacementCandidate {
+        private final String path;
+        private final SourceFile after;
+
+        private ReplacementCandidate(String path, SourceFile after) {
+            this.path = path;
+            this.after = after;
+        }
+    }
+}

--- a/src/main/java/io/github/devanshops/rewrite/helidon/ModuleAtomicMigrationRecipe.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/ModuleAtomicMigrationRecipe.java
@@ -1,0 +1,163 @@
+package io.github.devanshops.rewrite.helidon;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Collection;
+
+/**
+ * Deep seam for module-atomic migration families: collect, freeze once, then
+ * apply only the immutable committed plan.
+ */
+abstract class ModuleAtomicMigrationRecipe
+        extends ScanningRecipe<ModuleAtomicMigrationCoordinator> {
+
+    @Override
+    public final ModuleAtomicMigrationCoordinator getInitialValue(ExecutionContext ctx) {
+        return new ModuleAtomicMigrationCoordinator();
+    }
+
+    @Override
+    public final TreeVisitor<?, ExecutionContext> getScanner(
+            final ModuleAtomicMigrationCoordinator coordinator) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                if (!(tree instanceof SourceFile)) {
+                    return tree;
+                }
+                stopAfterPreVisit();
+                SourceFile sourceFile = (SourceFile) tree;
+                coordinator.record(sourceFile);
+                ModuleReadinessEvidenceScanner.scanSource(
+                        sourceFile, coordinator.readinessIndex());
+                scanMigrationFamily(sourceFile, coordinator, ctx);
+                return sourceFile;
+            }
+        };
+    }
+
+    protected void scanMigrationFamily(SourceFile sourceFile,
+                                       ModuleAtomicMigrationCoordinator coordinator,
+                                       ExecutionContext ctx) {
+        // The public assessment recipe intentionally has no mutating family plan.
+    }
+
+    @Override
+    public final Collection<? extends SourceFile> generate(
+            ModuleAtomicMigrationCoordinator coordinator,
+            Collection<SourceFile> generatedInThisCycle,
+            ExecutionContext ctx) {
+        coordinator.freeze(generatedSourcesForPlanning(
+                coordinator, generatedInThisCycle, ctx));
+        reportFrozenPlan(coordinator, ctx);
+        return coordinator.generatedSources();
+    }
+
+    /** Testable composition boundary for the generated sources visible at freeze time. */
+    protected Collection<SourceFile> generatedSourcesForPlanning(
+            ModuleAtomicMigrationCoordinator coordinator,
+            Collection<SourceFile> generatedInThisCycle,
+            ExecutionContext ctx) {
+        return generatedInThisCycle;
+    }
+
+    protected void reportFrozenPlan(ModuleAtomicMigrationCoordinator coordinator,
+                                    ExecutionContext ctx) {
+        // Reporting is a recipe concern; planning and apply remain table-agnostic.
+    }
+
+    @Override
+    public final TreeVisitor<?, ExecutionContext> getVisitor(
+            final ModuleAtomicMigrationCoordinator coordinator) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                if (!(tree instanceof SourceFile)) {
+                    return tree;
+                }
+                stopAfterPreVisit();
+                SourceFile sourceFile = coordinator.applyReplacement((SourceFile) tree);
+                sourceFile = mark(sourceFile, coordinator);
+                if (sourceFile instanceof G.CompilationUnit) {
+                    return new GroovyIsoVisitor<ExecutionContext>() {
+                        @Override
+                        public J.MethodInvocation visitMethodInvocation(
+                                J.MethodInvocation method,
+                                ExecutionContext executionContext) {
+                            return mark(super.visitMethodInvocation(method, executionContext),
+                                    coordinator);
+                        }
+                    }.visit(sourceFile, ctx);
+                }
+                if (sourceFile instanceof K.CompilationUnit) {
+                    return new KotlinIsoVisitor<ExecutionContext>() {
+                        @Override
+                        public J.MethodInvocation visitMethodInvocation(
+                                J.MethodInvocation method,
+                                ExecutionContext executionContext) {
+                            return mark(super.visitMethodInvocation(method, executionContext),
+                                    coordinator);
+                        }
+                    }.visit(sourceFile, ctx);
+                }
+                if (sourceFile instanceof J.CompilationUnit) {
+                    return new JavaIsoVisitor<ExecutionContext>() {
+                        @Override
+                        public J.Import visitImport(J.Import anImport,
+                                                    ExecutionContext executionContext) {
+                            return mark(super.visitImport(anImport, executionContext), coordinator);
+                        }
+
+                        @Override
+                        public J.FieldAccess visitFieldAccess(
+                                J.FieldAccess fieldAccess,
+                                ExecutionContext executionContext) {
+                            return mark(super.visitFieldAccess(fieldAccess, executionContext),
+                                    coordinator);
+                        }
+                    }.visit(sourceFile, ctx);
+                }
+                if (sourceFile instanceof Xml.Document) {
+                    return new XmlIsoVisitor<ExecutionContext>() {
+                        @Override
+                        public Xml.Tag visitTag(Xml.Tag tag,
+                                               ExecutionContext executionContext) {
+                            return mark(super.visitTag(tag, executionContext), coordinator);
+                        }
+                    }.visit(sourceFile, ctx);
+                }
+                return sourceFile;
+            }
+        };
+    }
+
+    private static <T extends Tree> T mark(
+            T tree, ModuleAtomicMigrationCoordinator coordinator) {
+        String description = coordinator.markerDescription(tree.getId());
+        if (description == null) {
+            return tree;
+        }
+        for (SearchResult existing : tree.getMarkers().findAll(SearchResult.class)) {
+            if (description.equals(existing.getDescription())) {
+                return tree;
+            }
+        }
+        return SearchResult.found(tree, description);
+    }
+}

--- a/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessDecision.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessDecision.java
@@ -1,0 +1,67 @@
+package io.github.devanshops.rewrite.helidon;
+
+import io.github.devanshops.rewrite.helidon.table.ModuleMigrationReadinessTable;
+
+/** One deterministic module eligibility or refusal record. */
+final class ModuleReadinessDecision {
+    static final String PROFILE = "HELIDON_MP_CONSERVATIVE";
+
+    private final String modulePath;
+    private final String buildSystem;
+    private final String outcome;
+    private final String sourcePath;
+    private final String sourceKind;
+    private final String feature;
+    private final String construct;
+    private final String reasonCode;
+    private final String reason;
+    private final String suggestedDirection;
+    private final String occurrenceKey;
+
+    private ModuleReadinessDecision(String modulePath, String buildSystem, String outcome,
+                                    String sourcePath, String sourceKind, String feature,
+                                    String construct, String reasonCode, String reason,
+                                    String suggestedDirection, String occurrenceKey) {
+        this.modulePath = modulePath;
+        this.buildSystem = buildSystem;
+        this.outcome = outcome;
+        this.sourcePath = sourcePath;
+        this.sourceKind = sourceKind;
+        this.feature = feature;
+        this.construct = construct;
+        this.reasonCode = reasonCode;
+        this.reason = reason;
+        this.suggestedDirection = suggestedDirection;
+        this.occurrenceKey = occurrenceKey;
+    }
+
+    static ModuleReadinessDecision eligible(String modulePath, String buildSystem,
+                                             String buildPath) {
+        return new ModuleReadinessDecision(modulePath, buildSystem,
+                "ELIGIBLE_FOR_PROFILE", buildPath, buildSystem,
+                "Module eligibility", modulePath,
+                "MODULE_ELIGIBLE_FOR_PROFILE",
+                "No blocker was found in the supplied artifacts for this conservative profile; this is not runtime certification.",
+                "Review the profile boundary before activating a future module-atomic migration",
+                modulePath + "\u0000eligible");
+    }
+
+    static ModuleReadinessDecision refused(String modulePath, String buildSystem,
+                                            ModuleReadinessEvidence evidence) {
+        return new ModuleReadinessDecision(modulePath, buildSystem, "REFUSED",
+                evidence.sourcePath, evidence.sourceKind, evidence.feature,
+                evidence.construct, evidence.reasonCode, evidence.reason,
+                evidence.suggestedDirection, evidence.occurrenceKey());
+    }
+
+    String rowKey() {
+        return modulePath + '\u0000' + outcome + '\u0000' + sourcePath + '\u0000' +
+               reasonCode + '\u0000' + construct + '\u0000' + occurrenceKey;
+    }
+
+    ModuleMigrationReadinessTable.Row toRow() {
+        return new ModuleMigrationReadinessTable.Row(modulePath, buildSystem, PROFILE, outcome,
+                sourcePath, sourceKind, feature, construct, reasonCode, reason,
+                suggestedDirection);
+    }
+}

--- a/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessEvidence.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessEvidence.java
@@ -1,0 +1,73 @@
+package io.github.devanshops.rewrite.helidon;
+
+import java.util.UUID;
+
+/** Redacted, occurrence-level evidence considered by the module readiness planner. */
+final class ModuleReadinessEvidence {
+    static final String ALL_MODULES = "<all-supplied-modules>";
+    final String sourcePath;
+    final String sourceKind;
+    final String feature;
+    final String construct;
+    final String reasonCode;
+    final String reason;
+    final String suggestedDirection;
+    final UUID markerId;
+    final boolean markerSafe;
+    private final String occurrenceToken;
+
+    ModuleReadinessEvidence(String sourcePath, String sourceKind, String feature,
+                            String construct, String reasonCode, String reason,
+                            String suggestedDirection, UUID markerId, boolean markerSafe) {
+        this(sourcePath, sourceKind, feature, construct, reasonCode, reason,
+                suggestedDirection, markerId, markerSafe, null);
+    }
+
+    private ModuleReadinessEvidence(String sourcePath, String sourceKind, String feature,
+                                    String construct, String reasonCode, String reason,
+                                    String suggestedDirection, UUID markerId,
+                                    boolean markerSafe, String occurrenceToken) {
+        this.sourcePath = sourcePath;
+        this.sourceKind = sourceKind;
+        this.feature = feature;
+        this.construct = construct;
+        this.reasonCode = reasonCode;
+        this.reason = reason;
+        this.suggestedDirection = suggestedDirection;
+        this.markerId = markerId;
+        this.markerSafe = markerSafe;
+        this.occurrenceToken = occurrenceToken;
+    }
+
+    String evidenceKey() {
+        return sourcePath + '\u0000' + sourceKind + '\u0000' + feature + '\u0000' +
+               construct + '\u0000' + reasonCode;
+    }
+
+    String occurrenceKey() {
+        return evidenceKey() + '\u0000' + locationToken();
+    }
+
+    String markerDescription() {
+        return "REFUSED [" + reasonCode + "]: " + reason;
+    }
+
+    ModuleReadinessEvidence atSourcePath(String path) {
+        return new ModuleReadinessEvidence(path, sourceKind, feature, construct,
+                reasonCode, reason, suggestedDirection, markerId, markerSafe,
+                occurrenceToken);
+    }
+
+    ModuleReadinessEvidence withOccurrenceSuffix(int suffix) {
+        return new ModuleReadinessEvidence(sourcePath, sourceKind, feature, construct,
+                reasonCode, reason, suggestedDirection, markerId, markerSafe,
+                locationToken() + '#' + suffix);
+    }
+
+    private String locationToken() {
+        if (occurrenceToken != null) {
+            return occurrenceToken;
+        }
+        return markerId == null ? "unlocated" : markerId.toString();
+    }
+}

--- a/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessEvidenceScanner.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessEvidenceScanner.java
@@ -1,0 +1,1181 @@
+package io.github.devanshops.rewrite.helidon;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.properties.PropertiesIsoVisitor;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.ResolvedPom;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Collects redacted readiness evidence without changing the supplied source tree. */
+final class ModuleReadinessEvidenceScanner {
+    private static final String SPRING_PREFIX = "org.springframework.";
+    private static final String SPRING_XML_NAMESPACE_PREFIX =
+            "http://www.springframework.org/schema/";
+
+    private ModuleReadinessEvidenceScanner() {
+    }
+
+    static void scanSource(SourceFile sourceFile, ModuleReadinessIndex index) {
+        String fileName = sourceFile.getSourcePath().getFileName().toString();
+        if (recordUnparsedEvidenceArtifact(sourceFile, index, fileName)) {
+            return;
+        }
+        if (sourceFile instanceof G.CompilationUnit &&
+                ("build.gradle".equals(fileName) || "settings.gradle".equals(fileName))) {
+            scanGradle((G.CompilationUnit) sourceFile, index);
+        } else if (sourceFile instanceof G.CompilationUnit) {
+            recordUnsupportedLanguage(sourceFile, index, "GROOVY");
+        } else if (sourceFile instanceof K.CompilationUnit &&
+                ("build.gradle.kts".equals(fileName) ||
+                        "settings.gradle.kts".equals(fileName))) {
+            scanKotlinGradle((K.CompilationUnit) sourceFile, index);
+        } else if (sourceFile instanceof K.CompilationUnit) {
+            recordUnsupportedLanguage(sourceFile, index, "KOTLIN");
+        } else if (sourceFile instanceof J.CompilationUnit) {
+            scanJava((J.CompilationUnit) sourceFile, index);
+        } else if (sourceFile instanceof Xml.Document && "pom.xml".equals(fileName)) {
+            scanMaven((Xml.Document) sourceFile, index);
+        } else if (sourceFile instanceof Xml.Document) {
+            scanSpringXml((Xml.Document) sourceFile, index);
+        } else if (sourceFile instanceof Properties.File) {
+            if (isSpringFactories(sourceFile.getSourcePath())) {
+                scanSpringFactories((Properties.File) sourceFile, index);
+            } else if (isApplicationProperties(sourceFile.getSourcePath())) {
+                scanApplicationProperties((Properties.File) sourceFile, index);
+            }
+        } else if (sourceFile instanceof Yaml.Documents &&
+                isApplicationYaml(sourceFile.getSourcePath())) {
+            scanApplicationYaml((Yaml.Documents) sourceFile, index);
+        } else if (sourceFile instanceof PlainText &&
+                isAutoConfigurationImports(sourceFile.getSourcePath())) {
+            scanAutoConfigurationImports((PlainText) sourceFile, index);
+        } else if ((fileName.endsWith(".kt") || fileName.endsWith(".kts")) &&
+                !"build.gradle.kts".equals(fileName) &&
+                !"settings.gradle.kts".equals(fileName)) {
+            recordUnsupportedLanguage(sourceFile, index, "KOTLIN");
+        } else if (fileName.endsWith(".groovy")) {
+            recordUnsupportedLanguage(sourceFile, index, "GROOVY");
+        }
+    }
+
+    private static boolean recordUnparsedEvidenceArtifact(
+            SourceFile sourceFile, ModuleReadinessIndex index, String fileName) {
+        String sourceKind = null;
+        if (fileName.endsWith(".java") && !(sourceFile instanceof J.CompilationUnit)) {
+            sourceKind = ModuleReadinessIndex.javaSourceKind(
+                    ModuleReadinessIndex.normalize(sourceFile.getSourcePath()));
+        } else if ("settings.gradle".equals(fileName) &&
+                !(sourceFile instanceof G.CompilationUnit)) {
+            sourceKind = "GRADLE_GROOVY";
+        } else if ("settings.gradle.kts".equals(fileName) &&
+                !(sourceFile instanceof K.CompilationUnit)) {
+            sourceKind = "GRADLE_KOTLIN";
+        } else if (isApplicationProperties(sourceFile.getSourcePath()) &&
+                !(sourceFile instanceof Properties.File)) {
+            sourceKind = "SPRING_PROPERTIES";
+        } else if (isApplicationYaml(sourceFile.getSourcePath()) &&
+                !(sourceFile instanceof Yaml.Documents)) {
+            sourceKind = "SPRING_YAML";
+        } else if (isSpringFactories(sourceFile.getSourcePath()) &&
+                !(sourceFile instanceof Properties.File)) {
+            sourceKind = "SPRING_FACTORIES";
+        } else if (fileName.endsWith(".xml") && !"pom.xml".equals(fileName) &&
+                !(sourceFile instanceof Xml.Document)) {
+            sourceKind = "SPRING_XML";
+        } else if (isAutoConfigurationImports(sourceFile.getSourcePath()) &&
+                !(sourceFile instanceof PlainText)) {
+            sourceKind = "SPRING_AUTOCONFIG_IMPORTS";
+        }
+        if (sourceKind == null) {
+            return false;
+        }
+        String sourcePath = ModuleReadinessIndex.normalize(sourceFile.getSourcePath());
+        index.recordEvidence(new ModuleReadinessEvidence(sourcePath, sourceKind,
+                "Incomplete artifact evidence", "Unparsed " + sourceKind + " artifact",
+                "MODULE_EVIDENCE_ARTIFACT_UNPARSED",
+                "A recognized evidence-bearing artifact was not parsed into its expected model",
+                "Supply parseable source before module migration",
+                sourceFile.getId(), false));
+        return true;
+    }
+
+    private static void recordUnsupportedLanguage(
+            SourceFile sourceFile, ModuleReadinessIndex index, String language) {
+        String sourcePath = ModuleReadinessIndex.normalize(sourceFile.getSourcePath());
+        index.recordEvidence(new ModuleReadinessEvidence(sourcePath,
+                language + "_SOURCE", "Unsupported application source language",
+                language + " application source", "MODULE_UNSUPPORTED_SOURCE_LANGUAGE",
+                "The conservative profile does not analyze this application source language",
+                "Add a bounded source-language migration family before module migration",
+                sourceFile.getId(), true));
+    }
+
+    static void scanJava(final J.CompilationUnit compilationUnit,
+                         final ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(
+                compilationUnit.getSourcePath());
+        final String sourceKind = ModuleReadinessIndex.javaSourceKind(sourcePath);
+        new JavaIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public J.Import visitImport(J.Import anImport, ModuleReadinessIndex accumulator) {
+                J.Import visited = super.visitImport(anImport, accumulator);
+                String typeName = visited.getTypeName();
+                if (typeName.startsWith(SPRING_PREFIX)) {
+                    JavaType importType = visited.getQualid().getType();
+                    if (visited.isStatic() && visited.getQualid().getTarget() != null) {
+                        importType = visited.getQualid().getTarget().getType();
+                    }
+                    accumulator.recordEvidence(javaEvidence(sourcePath, sourceKind, typeName,
+                            visited.getId(), TypeUtils.asFullyQualified(importType) == null));
+                }
+                return visited;
+            }
+
+            @Override
+            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess,
+                                                  ModuleReadinessIndex accumulator) {
+                J.FieldAccess visited = super.visitFieldAccess(fieldAccess, accumulator);
+                if (getCursor().firstEnclosing(J.Import.class) != null) {
+                    return visited;
+                }
+                JavaType.FullyQualified type = TypeUtils.asFullyQualified(visited.getType());
+                String typeName = type == null ? "" : type.getFullyQualifiedName();
+                if (typeName.startsWith(SPRING_PREFIX)) {
+                    accumulator.recordEvidence(javaEvidence(sourcePath, sourceKind, typeName,
+                            visited.getId(), false));
+                } else if (!isTargetOfParentFieldAccess(getCursor(), visited)) {
+                    String syntax = qualifiedSyntax(visited);
+                    if (syntax.startsWith(SPRING_PREFIX)) {
+                        accumulator.recordEvidence(javaEvidence(sourcePath, sourceKind, syntax,
+                                visited.getId(), true));
+                    }
+                }
+                return visited;
+            }
+        }.visit(compilationUnit, index);
+    }
+
+    private static ModuleReadinessEvidence javaEvidence(
+            String sourcePath, String sourceKind, String construct,
+            java.util.UUID markerId, boolean missingAttribution) {
+        if (missingAttribution) {
+            return new ModuleReadinessEvidence(sourcePath, sourceKind,
+                    "Java type attribution", construct, "MODULE_MISSING_ATTRIBUTION",
+                    "Spring Java syntax cannot be planned without complete type attribution",
+                    "Supply the complete Java parser classpath before module migration",
+                    markerId, true);
+        }
+        return new ModuleReadinessEvidence(sourcePath, sourceKind,
+                "Spring Java residue", construct, "MODULE_SPRING_JAVA_RESIDUE",
+                "Spring Java residue is outside the conservative module profile",
+                "Migrate or remove this Spring API with a bounded recipe",
+                markerId, true);
+    }
+
+    private static boolean isTargetOfParentFieldAccess(Cursor cursor, J.FieldAccess fieldAccess) {
+        Cursor parent = cursor.getParentTreeCursor();
+        if (parent == null || !(parent.getValue() instanceof J.FieldAccess)) {
+            return false;
+        }
+        J.FieldAccess parentAccess = (J.FieldAccess) parent.getValue();
+        return parentAccess.getTarget().getId().equals(fieldAccess.getId());
+    }
+
+    private static String qualifiedSyntax(Expression expression) {
+        if (expression instanceof J.Identifier) {
+            return ((J.Identifier) expression).getSimpleName();
+        }
+        if (expression instanceof J.FieldAccess) {
+            J.FieldAccess access = (J.FieldAccess) expression;
+            String target = qualifiedSyntax(access.getTarget());
+            return target.isEmpty() ? access.getSimpleName() :
+                    target + '.' + access.getSimpleName();
+        }
+        return "";
+    }
+
+    static void scanMaven(final Xml.Document document,
+                          final ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(document.getSourcePath());
+        final ResolvedPom resolvedPom = document.getMarkers()
+                .findFirst(MavenResolutionResult.class)
+                .map(MavenResolutionResult::getPom)
+                .orElse(null);
+        new XmlIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ModuleReadinessIndex accumulator) {
+                Xml.Tag visited = super.visitTag(tag, accumulator);
+                String name = localName(visited.getName());
+                if (!"parent".equals(name) && !"dependency".equals(name) &&
+                        !"plugin".equals(name)) {
+                    return visited;
+                }
+                String groupId = visited.getChildValue("groupId").orElse("");
+                String artifactId = visited.getChildValue("artifactId").orElse("");
+                String version = visited.getChildValue("version").orElse("");
+                String requestedGroup = groupId;
+                if ("plugin".equals(name) && requestedGroup.isEmpty()) {
+                    requestedGroup = "org.apache.maven.plugins";
+                }
+                boolean dynamic = containsPlaceholder(requestedGroup) ||
+                        containsPlaceholder(artifactId) || containsPlaceholder(version);
+                if (dynamic && resolvedPom != null) {
+                    GroupArtifactVersion resolved = resolvedPom.getValues(
+                            new GroupArtifactVersion(requestedGroup, artifactId, version));
+                    if (resolved != null && completeCoordinate(resolved, !version.isEmpty())) {
+                        groupId = resolved.getGroupId();
+                        artifactId = resolved.getArtifactId();
+                        version = resolved.getVersion();
+                        dynamic = false;
+                    }
+                }
+                if (dynamic || requestedGroup.isEmpty() || artifactId.isEmpty()) {
+                    accumulator.recordEvidence(new ModuleReadinessEvidence(
+                            sourcePath, "MAVEN", "Incomplete build evidence",
+                            "Unresolved Maven coordinate",
+                            "MODULE_BUILD_EVIDENCE_INCOMPLETE",
+                            "An unresolved Maven declaration can hide Spring build residue",
+                            "Supply a fully resolved Maven model before module migration",
+                            visited.getId(), true));
+                    return visited;
+                }
+                if (!isSpringBuildGroup(groupId)) {
+                    return visited;
+                }
+                accumulator.recordEvidence(new ModuleReadinessEvidence(
+                        sourcePath, "MAVEN", "Spring build residue",
+                        groupId + ':' + artifactId, "MODULE_SPRING_BUILD_RESIDUE",
+                        "Spring build residue is outside the conservative module profile",
+                        "Migrate the build and remove Spring only after module closure",
+                        visited.getId(), true));
+                return visited;
+            }
+        }.visit(document, index);
+    }
+
+    private static boolean containsPlaceholder(String value) {
+        return value != null && value.contains("${");
+    }
+
+    private static boolean completeCoordinate(
+            GroupArtifactVersion coordinate, boolean requireVersion) {
+        return coordinate.getGroupId() != null && !coordinate.getGroupId().isEmpty() &&
+               !containsPlaceholder(coordinate.getGroupId()) &&
+               coordinate.getArtifactId() != null && !coordinate.getArtifactId().isEmpty() &&
+               !containsPlaceholder(coordinate.getArtifactId()) &&
+               (!requireVersion || (coordinate.getVersion() != null &&
+                       !coordinate.getVersion().isEmpty() &&
+                       !containsPlaceholder(coordinate.getVersion())));
+    }
+
+    static void scanGradle(final G.CompilationUnit compilationUnit,
+                           final ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(
+                compilationUnit.getSourcePath());
+        new GroovyIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+                                                            ModuleReadinessIndex accumulator) {
+                J.MethodInvocation visited = super.visitMethodInvocation(method, accumulator);
+                assessGradleMethod(visited, accumulator, sourcePath, "GRADLE_GROOVY",
+                        getCursor());
+                return visited;
+            }
+
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier identifier,
+                                                ModuleReadinessIndex accumulator) {
+                J.Identifier visited = super.visitIdentifier(identifier, accumulator);
+                assessGradlePluginAccessor(visited, accumulator, sourcePath,
+                        "GRADLE_GROOVY", getCursor());
+                return visited;
+            }
+
+            @Override
+            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess,
+                                                  ModuleReadinessIndex accumulator) {
+                J.FieldAccess visited = super.visitFieldAccess(fieldAccess, accumulator);
+                assessGradlePluginAccessor(visited, accumulator, sourcePath,
+                        "GRADLE_GROOVY", getCursor());
+                return visited;
+            }
+        }.visit(compilationUnit, index);
+    }
+
+    static void scanKotlinGradle(final K.CompilationUnit compilationUnit,
+                                 final ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(
+                compilationUnit.getSourcePath());
+        new KotlinIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+                                                            ModuleReadinessIndex accumulator) {
+                J.MethodInvocation visited = super.visitMethodInvocation(method, accumulator);
+                assessGradleMethod(visited, accumulator, sourcePath, "GRADLE_KOTLIN",
+                        getCursor());
+                return visited;
+            }
+
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier identifier,
+                                                ModuleReadinessIndex accumulator) {
+                J.Identifier visited = super.visitIdentifier(identifier, accumulator);
+                assessGradlePluginAccessor(visited, accumulator, sourcePath,
+                        "GRADLE_KOTLIN", getCursor());
+                return visited;
+            }
+
+            @Override
+            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess,
+                                                  ModuleReadinessIndex accumulator) {
+                J.FieldAccess visited = super.visitFieldAccess(fieldAccess, accumulator);
+                assessGradlePluginAccessor(visited, accumulator, sourcePath,
+                        "GRADLE_KOTLIN", getCursor());
+                return visited;
+            }
+        }.visit(compilationUnit, index);
+    }
+
+    private static void assessGradleMethod(J.MethodInvocation method,
+                                           ModuleReadinessIndex index,
+                                           String sourcePath, String sourceKind,
+                                           Cursor cursor) {
+        String methodName = method.getSimpleName();
+        String literal = firstStringArgument(method);
+        if (isSettingsPath(sourcePath) && isGradleReactorDeclaration(methodName)) {
+            boolean unresolved = method.getArguments().isEmpty();
+            for (Expression argument : method.getArguments()) {
+                if (argument instanceof J.Literal &&
+                        ((J.Literal) argument).getValue() instanceof String) {
+                    index.recordGradleProjectReference(sourcePath,
+                            (String) ((J.Literal) argument).getValue(), methodName,
+                            method.getId());
+                } else {
+                    unresolved = true;
+                }
+            }
+            if (unresolved) {
+                index.recordEvidence(new ModuleReadinessEvidence(
+                        sourcePath, sourceKind, "Incomplete reactor topology",
+                        "Unresolved Gradle " + methodName + " declaration",
+                        "MODULE_REACTOR_DECLARATION_UNRESOLVED",
+                        "A dynamic Gradle reactor declaration cannot be reconciled " +
+                                "with the supplied build roots",
+                        "Supply literal Gradle reactor declarations before module migration",
+                        method.getId(), true));
+            }
+            return;
+        }
+        GradlePluginCall pluginCall = classifyGradlePluginCall(method, cursor);
+        if (pluginCall == GradlePluginCall.LEGACY_APPLY) {
+            String plugin = mapArgument(method, "plugin");
+            if (plugin != null) {
+                if (isSpringPluginId(plugin)) {
+                    recordGradleEvidence(index, sourcePath, sourceKind, plugin, method.getId());
+                }
+            } else if (hasNamedArgument(method, "plugin")) {
+                recordIncompleteGradle(index, sourcePath, sourceKind,
+                        "Unresolved Gradle plugin declaration", method.getId());
+            }
+            if (hasNamedArgument(method, "from")) {
+                recordIncompleteGradle(index, sourcePath, sourceKind,
+                        "Unresolved Gradle external script declaration", method.getId());
+            }
+            return;
+        }
+        if (pluginCall == GradlePluginCall.APPLY) {
+            String chainedPluginId = selectedPluginId(method);
+            if (chainedPluginId != null) {
+                if (booleanArgument(method, 0) == null) {
+                    recordIncompleteGradle(index, sourcePath, sourceKind,
+                            "Unresolved Gradle plugin declaration", method.getId());
+                }
+                if (isSpringPluginId(chainedPluginId)) {
+                    recordGradleEvidence(index, sourcePath, sourceKind,
+                            chainedPluginId, method.getId());
+                }
+                return;
+            }
+        }
+        if (pluginCall == GradlePluginCall.ID ||
+                pluginCall == GradlePluginCall.APPLY) {
+            if (literal == null) {
+                recordIncompleteGradle(index, sourcePath, sourceKind,
+                        "Unresolved Gradle plugin declaration", method.getId());
+            } else if (isSpringPluginId(literal)) {
+                recordGradleEvidence(index, sourcePath, sourceKind, literal, method.getId());
+            }
+            return;
+        }
+        if (pluginCall == GradlePluginCall.ALIAS) {
+            recordIncompleteGradle(index, sourcePath, sourceKind,
+                    "Unresolved Gradle dependency declaration", method.getId());
+            return;
+        }
+        if (pluginCall == GradlePluginCall.UNSUPPORTED) {
+            recordIncompleteGradle(index, sourcePath, sourceKind,
+                    "Unresolved Gradle plugin declaration", method.getId());
+            return;
+        }
+        if (pluginCall == GradlePluginCall.KNOWN_STATIC) {
+            String chainedPluginId = selectedPluginId(method);
+            if (chainedPluginId != null && isSpringPluginId(chainedPluginId)) {
+                recordGradleEvidence(index, sourcePath, sourceKind,
+                        chainedPluginId, method.getId());
+            }
+            return;
+        }
+        if ("project".equals(methodName)) {
+            return;
+        }
+        GradleDependencyCall dependencyCall = classifyGradleDependencyCall(method, cursor);
+        if (dependencyCall == GradleDependencyCall.NONE) {
+            return;
+        }
+        if (dependencyCall == GradleDependencyCall.UNSUPPORTED) {
+            recordIncompleteGradle(index, sourcePath, sourceKind,
+                    "Unresolved Gradle dependency declaration", method.getId());
+            return;
+        }
+        if (dependencyCall == GradleDependencyCall.ADD) {
+            if (isStaticProjectDependency(method, 1)) {
+                return;
+            }
+            String notation = stringArgument(method, 1);
+            if (notation == null) {
+                recordIncompleteGradle(index, sourcePath, sourceKind,
+                        "Unresolved Gradle dependency declaration", method.getId());
+            } else {
+                String coordinate = springCoordinate(notation);
+                if (coordinate != null) {
+                    recordGradleEvidence(index, sourcePath, sourceKind, coordinate,
+                            method.getId());
+                }
+            }
+            return;
+        }
+        if (literal != null) {
+            String coordinate = springCoordinate(literal);
+            if (coordinate != null) {
+                recordGradleEvidence(index, sourcePath, sourceKind, coordinate, method.getId());
+            }
+            return;
+        }
+        String mapCoordinate = staticMapCoordinate(method);
+        if (mapCoordinate != null) {
+            String coordinate = springCoordinate(mapCoordinate);
+            if (coordinate != null) {
+                recordGradleEvidence(index, sourcePath, sourceKind, coordinate, method.getId());
+            }
+            return;
+        }
+        if (isStaticProjectDependency(method, 0)) {
+            return;
+        }
+        recordIncompleteGradle(index, sourcePath, sourceKind,
+                "Unresolved Gradle dependency declaration", method.getId());
+    }
+
+    private static GradleDependencyCall classifyGradleDependencyCall(
+            J.MethodInvocation method, Cursor cursor) {
+        if (!isDirectDependencyDeclaration(cursor) &&
+                !isDependencyHandlerReceiver(method)) {
+            return GradleDependencyCall.NONE;
+        }
+        String methodName = method.getSimpleName();
+        if ("add".equals(methodName)) {
+            return method.getArguments().size() == 2 ?
+                GradleDependencyCall.ADD : GradleDependencyCall.UNSUPPORTED;
+        }
+        if (methodName.startsWith("add")) {
+            return GradleDependencyCall.UNSUPPORTED;
+        }
+        return GradleDependencyCall.CONFIGURATION_ACCESSOR;
+    }
+
+    private static GradlePluginCall classifyGradlePluginCall(
+            J.MethodInvocation method, Cursor cursor) {
+        String methodName = method.getSimpleName();
+        if ("apply".equals(methodName) &&
+                (hasNamedArgument(method, "plugin") ||
+                        hasNamedArgument(method, "from")) &&
+                isGradleProjectOwnedInvocation(method)) {
+            return GradlePluginCall.LEGACY_APPLY;
+        }
+        if (!isDirectPluginBodyInvocation(cursor) &&
+                !isPluginHandlerReceiver(method)) {
+            return GradlePluginCall.NONE;
+        }
+        if ("id".equals(methodName)) {
+            return method.getArguments().size() == 1 ?
+                    GradlePluginCall.ID : GradlePluginCall.UNSUPPORTED;
+        }
+        if ("apply".equals(methodName)) {
+            return method.getArguments().size() == 1 ?
+                    GradlePluginCall.APPLY : GradlePluginCall.UNSUPPORTED;
+        }
+        if ("alias".equals(methodName)) {
+            return GradlePluginCall.ALIAS;
+        }
+        if (isKnownPluginDslMethod(methodName) &&
+                method.getArguments().size() == 1 &&
+                stringArgument(method, 0) != null) {
+            return GradlePluginCall.KNOWN_STATIC;
+        }
+        return GradlePluginCall.UNSUPPORTED;
+    }
+
+    private static boolean isGradleProjectOwnedInvocation(J.MethodInvocation method) {
+        if (method.getSelect() == null) {
+            return true;
+        }
+        if (isProjectReference(method.getSelect())) {
+            return true;
+        }
+        ReceiverOwnership ownership = receiverOwnership(
+                method.getSelect().getType(), "org.gradle.api.Project");
+        if (ownership != ReceiverOwnership.UNKNOWN) {
+            return ownership == ReceiverOwnership.MATCH;
+        }
+        return false;
+    }
+
+    private static String selectedPluginId(J.MethodInvocation method) {
+        return pluginIdFromRequest(method.getSelect());
+    }
+
+    private static String pluginIdFromRequest(Expression expression) {
+        if (!(expression instanceof J.MethodInvocation)) {
+            return null;
+        }
+        J.MethodInvocation request = (J.MethodInvocation) expression;
+        if ("id".equals(request.getSimpleName()) &&
+                request.getArguments().size() == 1) {
+            return stringArgument(request, 0);
+        }
+        if ("version".equals(request.getSimpleName()) &&
+                request.getArguments().size() == 1 &&
+                stringArgument(request, 0) != null) {
+            return pluginIdFromRequest(request.getSelect());
+        }
+        return null;
+    }
+
+    private static Boolean booleanArgument(J.MethodInvocation method, int index) {
+        if (method.getArguments().size() <= index ||
+                !(method.getArguments().get(index) instanceof J.Literal)) {
+            return null;
+        }
+        Object value = ((J.Literal) method.getArguments().get(index)).getValue();
+        return value instanceof Boolean ? (Boolean) value : null;
+    }
+
+    private static void assessGradlePluginAccessor(
+            Expression accessor, ModuleReadinessIndex index, String sourcePath,
+            String sourceKind, Cursor cursor) {
+        if (!isDirectPluginBodyExpression(cursor)) {
+            return;
+        }
+        String accessorName;
+        if (accessor instanceof J.Identifier) {
+            J.MethodInvocation enclosing = nearestEnclosingMethod(cursor);
+            if (enclosing != null && enclosing.getName().getId()
+                    .equals(accessor.getId())) {
+                return;
+            }
+            accessorName = ((J.Identifier) accessor).getSimpleName();
+        } else if (accessor instanceof J.FieldAccess) {
+            accessorName = qualifiedSyntax(accessor);
+        } else {
+            return;
+        }
+        if (!isKnownPluginAccessor(accessorName)) {
+            recordIncompleteGradle(index, sourcePath, sourceKind,
+                    "Unresolved Gradle plugin declaration", accessor.getId());
+        }
+    }
+
+    private static boolean isDirectPluginBodyExpression(Cursor cursor) {
+        Cursor parent = cursor.getParent();
+        while (parent != null) {
+            Object value = parent.getValue();
+            if (value instanceof J.FieldAccess ||
+                    value instanceof J.VariableDeclarations ||
+                    value instanceof J.Assignment) {
+                return false;
+            }
+            if (value instanceof J.MethodInvocation) {
+                return "plugins".equals(
+                        ((J.MethodInvocation) value).getSimpleName());
+            }
+            parent = parent.getParent();
+        }
+        return false;
+    }
+
+    private static J.MethodInvocation nearestEnclosingMethod(Cursor cursor) {
+        Cursor parent = cursor.getParent();
+        while (parent != null) {
+            if (parent.getValue() instanceof J.MethodInvocation) {
+                return (J.MethodInvocation) parent.getValue();
+            }
+            parent = parent.getParent();
+        }
+        return null;
+    }
+
+    private static boolean isDirectPluginBodyInvocation(Cursor cursor) {
+        Cursor parent = cursor.getParent();
+        while (parent != null) {
+            Object value = parent.getValue();
+            if (value instanceof J.MethodInvocation) {
+                return "plugins".equals(
+                        ((J.MethodInvocation) value).getSimpleName());
+            }
+            parent = parent.getParent();
+        }
+        return false;
+    }
+
+    private static boolean isKnownPluginDslMethod(String methodName) {
+        return "id".equals(methodName) || "alias".equals(methodName) ||
+               "kotlin".equals(methodName) || "version".equals(methodName);
+    }
+
+    private static boolean isKnownPluginAccessor(String accessorName) {
+        return "java".equals(accessorName) || "java-library".equals(accessorName) ||
+               "javaLibrary".equals(accessorName) ||
+               "java-gradle-plugin".equals(accessorName) ||
+               "javaGradlePlugin".equals(accessorName) ||
+               "application".equals(accessorName) || "groovy".equals(accessorName) ||
+               "scala".equals(accessorName) || "war".equals(accessorName) ||
+               "ear".equals(accessorName) || "antlr".equals(accessorName) ||
+               "checkstyle".equals(accessorName) || "codenarc".equals(accessorName) ||
+               "pmd".equals(accessorName) || "jacoco".equals(accessorName) ||
+               "idea".equals(accessorName) || "eclipse".equals(accessorName) ||
+               "signing".equals(accessorName) || "maven-publish".equals(accessorName) ||
+               "mavenPublish".equals(accessorName) || "kotlin-dsl".equals(accessorName) ||
+               "kotlinDsl".equals(accessorName);
+    }
+
+    private static boolean isSettingsPath(String sourcePath) {
+        return sourcePath.endsWith("/settings.gradle") ||
+               sourcePath.endsWith("/settings.gradle.kts") ||
+               "settings.gradle".equals(sourcePath) ||
+               "settings.gradle.kts".equals(sourcePath);
+    }
+
+    private static boolean isPluginHandlerReceiver(J.MethodInvocation method) {
+        JavaType.Method methodType = method.getMethodType();
+        ReceiverOwnership methodOwnership = methodType == null ?
+                ReceiverOwnership.UNKNOWN : receiverOwnership(
+                        methodType.getDeclaringType(),
+                        "org.gradle.api.plugins.PluginManager",
+                        "org.gradle.api.plugins.PluginContainer");
+        if (methodOwnership != ReceiverOwnership.UNKNOWN) {
+            return methodOwnership == ReceiverOwnership.MATCH;
+        }
+        Expression select = method.getSelect();
+        if (select == null) {
+            return false;
+        }
+        ReceiverOwnership selectOwnership = receiverOwnership(select.getType(),
+                "org.gradle.api.plugins.PluginManager",
+                "org.gradle.api.plugins.PluginContainer");
+        if (selectOwnership == ReceiverOwnership.MATCH) {
+            return true;
+        }
+        String receiver = qualifiedSyntax(select);
+        if ("pluginManager".equals(receiver) || "plugins".equals(receiver) ||
+                "project.pluginManager".equals(receiver) ||
+                "project.plugins".equals(receiver)) {
+            return true;
+        }
+        if (!(select instanceof J.MethodInvocation)) {
+            return false;
+        }
+        J.MethodInvocation getter = (J.MethodInvocation) select;
+        if (!("getPluginManager".equals(getter.getSimpleName()) ||
+                "getPlugins".equals(getter.getSimpleName())) ||
+                !hasNoArguments(getter)) {
+            return false;
+        }
+        JavaType.Method getterType = getter.getMethodType();
+        ReceiverOwnership getterOwnership = getterType == null ?
+                ReceiverOwnership.UNKNOWN : receiverOwnership(
+                        getterType.getReturnType(),
+                        "org.gradle.api.plugins.PluginManager",
+                        "org.gradle.api.plugins.PluginContainer");
+        if (getterOwnership != ReceiverOwnership.UNKNOWN) {
+            return getterOwnership == ReceiverOwnership.MATCH;
+        }
+        Expression getterSelect = getter.getSelect();
+        return getterSelect == null || isProjectReference(getterSelect);
+    }
+
+    private static boolean isGradleReactorDeclaration(String methodName) {
+        return "include".equals(methodName) || "includeFlat".equals(methodName) ||
+               "includeBuild".equals(methodName);
+    }
+
+    private static boolean isDirectDependencyDeclaration(Cursor cursor) {
+        Cursor parent = cursor.getParent();
+        while (parent != null) {
+            Object value = parent.getValue();
+            if (value instanceof J.MethodInvocation) {
+                return "dependencies".equals(((J.MethodInvocation) value).getSimpleName());
+            }
+            parent = parent.getParent();
+        }
+        return false;
+    }
+
+    private static boolean isDependencyHandlerReceiver(J.MethodInvocation method) {
+        JavaType.Method methodType = method.getMethodType();
+        ReceiverOwnership methodOwnership = methodType == null ?
+                ReceiverOwnership.UNKNOWN : receiverOwnership(
+                        methodType.getDeclaringType(),
+                        "org.gradle.api.artifacts.dsl.DependencyHandler");
+        if (methodOwnership != ReceiverOwnership.UNKNOWN) {
+            return methodOwnership == ReceiverOwnership.MATCH;
+        }
+        Expression select = method.getSelect();
+        if (select == null) {
+            return false;
+        }
+        ReceiverOwnership selectOwnership = receiverOwnership(select.getType(),
+                "org.gradle.api.artifacts.dsl.DependencyHandler");
+        if (selectOwnership == ReceiverOwnership.MATCH) {
+            return true;
+        }
+        String receiver = qualifiedSyntax(select);
+        if ("dependencies".equals(receiver) ||
+                "project.dependencies".equals(receiver)) {
+            return true;
+        }
+        if (!(select instanceof J.MethodInvocation)) {
+            return false;
+        }
+        J.MethodInvocation getter = (J.MethodInvocation) select;
+        if (!"getDependencies".equals(getter.getSimpleName()) ||
+                !hasNoArguments(getter)) {
+            return false;
+        }
+        JavaType.Method getterType = getter.getMethodType();
+        ReceiverOwnership getterOwnership = getterType == null ?
+                ReceiverOwnership.UNKNOWN : receiverOwnership(
+                        getterType.getReturnType(),
+                        "org.gradle.api.artifacts.dsl.DependencyHandler");
+        if (getterOwnership != ReceiverOwnership.UNKNOWN) {
+            return getterOwnership == ReceiverOwnership.MATCH;
+        }
+        Expression getterSelect = getter.getSelect();
+        return getterSelect == null || isProjectReference(getterSelect);
+    }
+
+    private static boolean isProjectReference(Expression expression) {
+        if ("project".equals(qualifiedSyntax(expression))) {
+            return true;
+        }
+        if (!(expression instanceof J.MethodInvocation)) {
+            return false;
+        }
+        J.MethodInvocation project = (J.MethodInvocation) expression;
+        return ("project".equals(project.getSimpleName()) ||
+                "getProject".equals(project.getSimpleName())) &&
+               project.getSelect() == null && hasNoArguments(project);
+    }
+
+    private static boolean hasNoArguments(J.MethodInvocation method) {
+        return method.getArguments().isEmpty() ||
+               (method.getArguments().size() == 1 &&
+                       method.getArguments().get(0) instanceof J.Empty);
+    }
+
+    private static ReceiverOwnership receiverOwnership(
+            JavaType type, String... supportedTypes) {
+        if (TypeUtils.asFullyQualified(type) == null) {
+            return ReceiverOwnership.UNKNOWN;
+        }
+        for (String supportedType : supportedTypes) {
+            if (TypeUtils.isAssignableTo(supportedType, type)) {
+                return ReceiverOwnership.MATCH;
+            }
+        }
+        return ReceiverOwnership.INCOMPATIBLE;
+    }
+
+    private enum ReceiverOwnership {
+        MATCH,
+        INCOMPATIBLE,
+        UNKNOWN
+    }
+
+    private enum GradleDependencyCall {
+        NONE,
+        ADD,
+        CONFIGURATION_ACCESSOR,
+        UNSUPPORTED
+    }
+
+    private enum GradlePluginCall {
+        NONE,
+        LEGACY_APPLY,
+        ID,
+        APPLY,
+        ALIAS,
+        KNOWN_STATIC,
+        UNSUPPORTED
+    }
+
+    private static boolean isStaticProjectDependency(
+            J.MethodInvocation method, int notationIndex) {
+        if (method.getArguments().size() != notationIndex + 1 ||
+                !(method.getArguments().get(notationIndex) instanceof J.MethodInvocation)) {
+            return false;
+        }
+        J.MethodInvocation project =
+                (J.MethodInvocation) method.getArguments().get(notationIndex);
+        String path = firstStringArgument(project);
+        return "project".equals(project.getSimpleName()) &&
+               project.getSelect() == null && project.getArguments().size() == 1 &&
+               path != null && !path.trim().isEmpty();
+    }
+
+    private static void recordIncompleteGradle(
+            ModuleReadinessIndex index, String sourcePath, String sourceKind,
+            String construct, java.util.UUID markerId) {
+        index.recordEvidence(new ModuleReadinessEvidence(
+                sourcePath, sourceKind, "Incomplete build evidence", construct,
+                "MODULE_BUILD_EVIDENCE_INCOMPLETE",
+                "An unresolved Gradle declaration can hide Spring build residue",
+                "Supply a fully resolved Gradle model before module migration",
+                markerId, true));
+    }
+
+    private static void recordGradleEvidence(ModuleReadinessIndex index, String sourcePath,
+                                             String sourceKind, String construct,
+                                             java.util.UUID markerId) {
+        index.recordEvidence(new ModuleReadinessEvidence(
+                sourcePath, sourceKind, "Spring build residue", construct,
+                "MODULE_SPRING_BUILD_RESIDUE",
+                "Spring build residue is outside the conservative module profile",
+                "Migrate the build and remove Spring only after module closure",
+                markerId, true));
+    }
+
+    private static String firstStringArgument(J.MethodInvocation method) {
+        return stringArgument(method, 0);
+    }
+
+    private static String stringArgument(J.MethodInvocation method, int index) {
+        if (method.getArguments().size() <= index ||
+                !(method.getArguments().get(index) instanceof J.Literal)) {
+            return null;
+        }
+        Object value = ((J.Literal) method.getArguments().get(index)).getValue();
+        return value instanceof String ? (String) value : null;
+    }
+
+    private static String staticMapCoordinate(J.MethodInvocation method) {
+        List<G.MapEntry> entries = mapEntries(method);
+        String group = mapString(entries, "group");
+        String name = mapString(entries, "name");
+        return group != null && name != null ? group + ':' + name : null;
+    }
+
+    private static String mapArgument(J.MethodInvocation method, String key) {
+        Expression argument = namedArgument(method, key);
+        if (!(argument instanceof J.Literal)) {
+            return null;
+        }
+        Object value = ((J.Literal) argument).getValue();
+        return value instanceof String ? (String) value : null;
+    }
+
+    private static boolean hasNamedArgument(
+            J.MethodInvocation method, String expectedKey) {
+        return namedArgument(method, expectedKey) != null;
+    }
+
+    private static Expression namedArgument(
+            J.MethodInvocation method, String expectedKey) {
+        for (Expression argument : method.getArguments()) {
+            if (argument instanceof G.MapEntry) {
+                G.MapEntry entry = (G.MapEntry) argument;
+                if (expectedKey.equals(normalizedMapKey(entry.getKey()))) {
+                    return entry.getValue();
+                }
+            } else if (argument instanceof G.MapLiteral) {
+                for (G.MapEntry entry : ((G.MapLiteral) argument).getElements()) {
+                    if (expectedKey.equals(normalizedMapKey(entry.getKey()))) {
+                        return entry.getValue();
+                    }
+                }
+            } else if (argument instanceof J.Assignment) {
+                J.Assignment assignment = (J.Assignment) argument;
+                if (assignment.getVariable() instanceof J.Identifier &&
+                        expectedKey.equals(((J.Identifier) assignment.getVariable())
+                                .getSimpleName())) {
+                    return assignment.getAssignment();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String normalizedMapKey(Expression expression) {
+        String key = expression.printTrimmed();
+        if ((key.startsWith("'") && key.endsWith("'")) ||
+                (key.startsWith("\"") && key.endsWith("\""))) {
+            return key.substring(1, key.length() - 1);
+        }
+        return key;
+    }
+
+    private static List<G.MapEntry> mapEntries(J.MethodInvocation method) {
+        List<G.MapEntry> entries = new ArrayList<G.MapEntry>();
+        for (Expression argument : method.getArguments()) {
+            if (argument instanceof G.MapEntry) {
+                entries.add((G.MapEntry) argument);
+            } else if (argument instanceof G.MapLiteral) {
+                entries.addAll(((G.MapLiteral) argument).getElements());
+            }
+        }
+        return entries;
+    }
+
+    private static String mapString(List<G.MapEntry> entries, String expectedKey) {
+        for (G.MapEntry entry : entries) {
+            String key = entry.getKey().printTrimmed();
+            if ((key.startsWith("'") && key.endsWith("'")) ||
+                    (key.startsWith("\"") && key.endsWith("\""))) {
+                key = key.substring(1, key.length() - 1);
+            }
+            if (!expectedKey.equals(key) || !(entry.getValue() instanceof J.Literal)) {
+                continue;
+            }
+            Object value = ((J.Literal) entry.getValue()).getValue();
+            if (value instanceof String) {
+                return (String) value;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isSpringPluginId(String pluginId) {
+        return "org.springframework.boot".equals(pluginId) ||
+               pluginId.startsWith("org.springframework.") ||
+               "io.spring.dependency-management".equals(pluginId) ||
+               pluginId.startsWith("io.spring.");
+    }
+
+    private static String springCoordinate(String declaration) {
+        String[] parts = declaration.split(":");
+        if (parts.length < 2 || !isSpringBuildGroup(parts[0]) || parts[1].isEmpty()) {
+            return null;
+        }
+        return parts[0] + ':' + parts[1];
+    }
+
+    private static boolean isSpringBuildGroup(String groupId) {
+        return "org.springframework".equals(groupId) ||
+               groupId.startsWith("org.springframework.") ||
+               "io.spring".equals(groupId) || groupId.startsWith("io.spring.");
+    }
+
+    static void scanSpringXml(Xml.Document document, ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(document.getSourcePath());
+        new XmlIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ModuleReadinessIndex accumulator) {
+                Xml.Tag visited = super.visitTag(tag, accumulator);
+                for (Xml.Attribute attribute : visited.getAttributes()) {
+                    if (attribute.getKeyAsString().startsWith("xmlns") &&
+                            attribute.getValueAsString().startsWith(
+                                    SPRING_XML_NAMESPACE_PREFIX)) {
+                        accumulator.recordEvidence(privateEvidence(sourcePath,
+                                "SPRING_XML", "Spring XML wiring",
+                                "Spring XML namespace", "MODULE_SPRING_XML",
+                                "Spring XML wiring is outside the conservative module profile",
+                                "Replace Spring XML wiring with explicit CDI beans and producers",
+                                visited.getId()));
+                        break;
+                    }
+                }
+                return visited;
+            }
+        }.visit(document, index);
+    }
+
+    static void scanApplicationProperties(final Properties.File properties,
+                                          final ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(properties.getSourcePath());
+        new PropertiesIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public Properties.Entry visitEntry(Properties.Entry entry,
+                                                ModuleReadinessIndex accumulator) {
+                Properties.Entry visited = super.visitEntry(entry, accumulator);
+                accumulator.recordEvidence(configurationEvidence(sourcePath,
+                        "SPRING_PROPERTIES", visited.getKey(), visited.getId()));
+                return visited;
+            }
+        }.visit(properties, index);
+    }
+
+    static void scanApplicationYaml(final Yaml.Documents documents,
+                                    final ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(documents.getSourcePath());
+        new YamlIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry,
+                                                        ModuleReadinessIndex accumulator) {
+                Yaml.Mapping.Entry visited = super.visitMappingEntry(entry, accumulator);
+                if (!(visited.getValue() instanceof Yaml.Mapping)) {
+                    String key = yamlKey(getCursor());
+                    accumulator.recordEvidence(configurationEvidence(sourcePath,
+                            "SPRING_YAML", key, visited.getId()));
+                }
+                return visited;
+            }
+        }.visit(documents, index);
+    }
+
+    static void scanSpringFactories(final Properties.File properties,
+                                    final ModuleReadinessIndex index) {
+        final String sourcePath = ModuleReadinessIndex.normalize(properties.getSourcePath());
+        new PropertiesIsoVisitor<ModuleReadinessIndex>() {
+            @Override
+            public Properties.Entry visitEntry(Properties.Entry entry,
+                                                ModuleReadinessIndex accumulator) {
+                Properties.Entry visited = super.visitEntry(entry, accumulator);
+                accumulator.recordEvidence(privateEvidence(sourcePath,
+                        "SPRING_FACTORIES", "Spring factories metadata", visited.getKey(),
+                        "MODULE_SPRING_METADATA",
+                        "Spring runtime discovery metadata is outside the conservative module profile",
+                        "Replace registration with explicit CDI discovery or target runtime metadata",
+                        visited.getId()));
+                return visited;
+            }
+        }.visit(properties, index);
+    }
+
+    static void scanAutoConfigurationImports(PlainText imports,
+                                             ModuleReadinessIndex index) {
+        if (!hasRegistrationLine(imports.getText())) {
+            return;
+        }
+        index.recordEvidence(privateEvidence(imports,
+                "SPRING_AUTOCONFIG_IMPORTS", "Spring Boot auto-configuration metadata",
+                "AutoConfiguration.imports entry", "MODULE_SPRING_METADATA",
+                "Spring runtime discovery metadata is outside the conservative module profile",
+                "Replace registration with explicit CDI discovery or target runtime metadata"));
+    }
+
+    static boolean isApplicationProperties(Path path) {
+        String fileName = path.getFileName().toString();
+        return "application.properties".equals(fileName) ||
+               (fileName.startsWith("application-") && fileName.endsWith(".properties"));
+    }
+
+    static boolean isApplicationYaml(Path path) {
+        String fileName = path.getFileName().toString();
+        return "application.yml".equals(fileName) || "application.yaml".equals(fileName) ||
+               (fileName.startsWith("application-") &&
+                       (fileName.endsWith(".yml") || fileName.endsWith(".yaml")));
+    }
+
+    static boolean isSpringFactories(Path path) {
+        return "spring.factories".equals(path.getFileName().toString()) &&
+               ModuleReadinessIndex.normalize(path).contains("/META-INF/");
+    }
+
+    static boolean isAutoConfigurationImports(Path path) {
+        return "org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+                .equals(path.getFileName().toString()) &&
+               ModuleReadinessIndex.normalize(path).contains("/META-INF/spring/");
+    }
+
+    private static String yamlKey(Cursor cursor) {
+        List<String> parts = new ArrayList<String>();
+        Cursor current = cursor;
+        while (current != null) {
+            Object value = current.getValue();
+            if (value instanceof Yaml.Mapping.Entry) {
+                parts.add(0, ((Yaml.Mapping.Entry) value).getKey().getValue());
+            }
+            current = current.getParent();
+        }
+        return String.join(".", parts);
+    }
+
+    private static boolean hasRegistrationLine(String text) {
+        for (String line : text.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ModuleReadinessEvidence configurationEvidence(
+            String sourcePath, String sourceKind, String key, java.util.UUID markerId) {
+        boolean springOwned = key.startsWith("spring.");
+        return privateEvidence(sourcePath, sourceKind,
+                springOwned ? "Spring configuration" : "Application configuration",
+                key, springOwned ? "MODULE_SPRING_CONFIGURATION" :
+                        "MODULE_APPLICATION_CONFIGURATION",
+                springOwned ?
+                        "Spring configuration is outside the conservative module profile" :
+                        "Application configuration has no proven target contract in the conservative module profile",
+                "Map the key to a documented MicroProfile Config contract", markerId);
+    }
+
+    private static ModuleReadinessEvidence privateEvidence(
+            org.openrewrite.SourceFile sourceFile, String sourceKind, String feature,
+            String construct, String reasonCode, String reason, String direction) {
+        return privateEvidence(ModuleReadinessIndex.normalize(sourceFile.getSourcePath()),
+                sourceKind, feature, construct, reasonCode, reason, direction,
+                sourceFile.getId());
+    }
+
+    private static ModuleReadinessEvidence privateEvidence(
+            String sourcePath, String sourceKind, String feature, String construct,
+            String reasonCode, String reason, String direction) {
+        return privateEvidence(sourcePath, sourceKind, feature, construct, reasonCode,
+                reason, direction, null);
+    }
+
+    private static ModuleReadinessEvidence privateEvidence(
+            String sourcePath, String sourceKind, String feature, String construct,
+            String reasonCode, String reason, String direction, java.util.UUID markerId) {
+        return new ModuleReadinessEvidence(sourcePath, sourceKind, feature, construct,
+                reasonCode, reason, direction, markerId, false);
+    }
+
+    private static String localName(String name) {
+        int colon = name.indexOf(':');
+        return colon < 0 ? name : name.substring(colon + 1);
+    }
+}

--- a/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessIndex.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/ModuleReadinessIndex.java
@@ -1,0 +1,489 @@
+package io.github.devanshops.rewrite.helidon;
+
+import org.openrewrite.SourceFile;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.xml.tree.Xml;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/** Builds and freezes module-scoped readiness decisions before reporting. */
+final class ModuleReadinessIndex {
+    private final Map<String, List<ModuleBuild>> builds =
+            new LinkedHashMap<String, List<ModuleBuild>>();
+    private final Map<String, ModuleReadinessEvidence> evidence =
+            new LinkedHashMap<String, ModuleReadinessEvidence>();
+    private final Map<String, ModuleArtifact> artifacts =
+            new LinkedHashMap<String, ModuleArtifact>();
+    private final Map<UUID, String> markers = new HashMap<UUID, String>();
+    private final List<ExpectedModule> expectedModules = new ArrayList<ExpectedModule>();
+    private final Map<String, Boolean> eligibilityByRoot =
+            new HashMap<String, Boolean>();
+    private List<ModuleReadinessDecision> planned;
+
+    synchronized void record(SourceFile sourceFile) {
+        String path = normalize(sourceFile.getSourcePath());
+        artifacts.put(path, new ModuleArtifact(path, sourceFile.getId(),
+                sourceFile instanceof J.CompilationUnit));
+        String fileName = sourceFile.getSourcePath().getFileName().toString();
+        if ("pom.xml".equals(fileName)) {
+            String root = parent(path);
+            UUID anchorId = sourceFile instanceof Xml.Document ?
+                    ((Xml.Document) sourceFile).getRoot().getId() : sourceFile.getId();
+            recordBuild(new ModuleBuild(root, path, "MAVEN", anchorId));
+            if (sourceFile instanceof Xml.Document) {
+                recordMavenModules((Xml.Document) sourceFile, root, path);
+                java.util.Optional<MavenResolutionResult> resolution =
+                        sourceFile.getMarkers().findFirst(MavenResolutionResult.class);
+                if (resolution.isPresent()) {
+                    String markerPath = normalize(resolution.get().getPom()
+                            .getRequested().getSourcePath());
+                    if (!path.equals(markerPath)) {
+                        recordEvidence(new ModuleReadinessEvidence(
+                                path, "MODULE_TOPOLOGY", "Module ownership topology",
+                                "Maven marker/path disagreement",
+                                "MODULE_OWNERSHIP_DISAGREEMENT",
+                                "The Maven build marker and supplied source path disagree",
+                                "Regenerate authoritative project markers before module migration",
+                                anchorId, true));
+                    }
+                }
+            }
+            if (!(sourceFile instanceof Xml.Document)) {
+                recordEvidence(unparsedBuild(path, "MAVEN", sourceFile.getId()));
+            }
+        } else if ("build.gradle".equals(fileName) || "build.gradle.kts".equals(fileName)) {
+            String root = parent(path);
+            String buildSystem = "build.gradle".equals(fileName) ?
+                    "GRADLE_GROOVY" : "GRADLE_KOTLIN";
+            recordBuild(new ModuleBuild(root, path, buildSystem, sourceFile.getId()));
+            boolean parsed = "build.gradle".equals(fileName) ?
+                    sourceFile instanceof G.CompilationUnit :
+                    sourceFile instanceof K.CompilationUnit;
+            if (!parsed) {
+                recordEvidence(unparsedBuild(path, buildSystem, sourceFile.getId()));
+            }
+        }
+    }
+
+    synchronized void recordGradleProjectReference(
+            String sourcePath, String notation, String declarationKind, UUID markerId) {
+        String normalizedNotation = notation.startsWith(":") ?
+                notation.substring(1) : notation;
+        if (normalizedNotation.isEmpty()) {
+            return;
+        }
+        String relative = normalizedNotation.replace(':', '/');
+        String declaringRoot = parent(sourcePath);
+        Path base = java.nio.file.Paths.get(declaringRoot);
+        if ("includeFlat".equals(declarationKind) && base.getParent() != null) {
+            base = base.getParent();
+        }
+        String expectedRoot = normalize(base.resolve(relative));
+        expectedModules.add(new ExpectedModule(sourcePath, expectedRoot,
+                notation, markerId, "GRADLE"));
+    }
+
+    private void recordMavenModules(Xml.Document document, String root, String pomPath) {
+        java.util.Optional<Xml.Tag> modules = document.getRoot().getChild("modules");
+        if (!modules.isPresent()) {
+            return;
+        }
+        for (Xml.Tag child : modules.get().getChildren("module")) {
+            String value = child.getValue().orElse("").trim();
+            if (value.isEmpty()) {
+                continue;
+            }
+            String expectedRoot = normalize(java.nio.file.Paths.get(root).resolve(value));
+            expectedModules.add(new ExpectedModule(pomPath, expectedRoot,
+                    value, child.getId(), "MAVEN"));
+        }
+    }
+
+    private static ModuleReadinessEvidence unparsedBuild(
+            String path, String buildSystem, UUID markerId) {
+        return new ModuleReadinessEvidence(path, buildSystem,
+                "Incomplete build evidence", "Unparsed build descriptor",
+                "MODULE_BUILD_DESCRIPTOR_UNPARSED",
+                "The supplied build descriptor was not parsed into its authoritative model",
+                "Supply a parseable build descriptor before module migration",
+                markerId, true);
+    }
+
+    private void recordBuild(ModuleBuild build) {
+        List<ModuleBuild> descriptors = builds.get(build.root);
+        if (descriptors == null) {
+            descriptors = new ArrayList<ModuleBuild>();
+            builds.put(build.root, descriptors);
+        }
+        descriptors.add(build);
+    }
+
+    synchronized void recordEvidence(ModuleReadinessEvidence finding) {
+        ModuleReadinessEvidence occurrence = finding;
+        int suffix = 2;
+        while (evidence.containsKey(occurrence.occurrenceKey())) {
+            occurrence = finding.withOccurrenceSuffix(suffix++);
+        }
+        evidence.put(occurrence.occurrenceKey(), occurrence);
+    }
+
+    synchronized List<ModuleReadinessEvidence> evidenceSnapshot() {
+        return new ArrayList<ModuleReadinessEvidence>(evidence.values());
+    }
+
+    synchronized List<ModuleReadinessDecision> decisions() {
+        if (planned != null) {
+            return planned;
+        }
+        recordIncompleteReactors();
+        List<ResolvedModule> ordered = new ArrayList<ResolvedModule>();
+        for (Map.Entry<String, List<ModuleBuild>> entry : builds.entrySet()) {
+            ordered.add(resolve(entry.getKey(), entry.getValue()));
+        }
+        Map<String, List<ModuleArtifact>> orphanGroups = orphanGroups();
+        for (Map.Entry<String, List<ModuleArtifact>> entry : orphanGroups.entrySet()) {
+            List<ModuleArtifact> group = entry.getValue();
+            Collections.sort(group, new Comparator<ModuleArtifact>() {
+                @Override
+                public int compare(ModuleArtifact left, ModuleArtifact right) {
+                    return left.path.compareTo(right.path);
+                }
+            });
+            ModuleArtifact anchor = safeAnchor(group);
+            if (anchor == null) {
+                anchor = group.get(0);
+            }
+            ModuleReadinessEvidence missingBuild = new ModuleReadinessEvidence(
+                    anchor.path, "MODULE_TOPOLOGY", "Module build topology",
+                    displayRoot(entry.getKey()), "MODULE_BUILD_ROOT_MISSING",
+                    "No Maven or Gradle build descriptor owns this supplied artifact",
+                    "Supply the authoritative module build descriptor before migration",
+                    null, false);
+            ordered.add(new ResolvedModule(entry.getKey(), anchor.path, "UNRESOLVED",
+                    anchor.markerSafe ? anchor.id : null, missingBuild));
+        }
+        Collections.sort(ordered, new Comparator<ResolvedModule>() {
+            @Override
+            public int compare(ResolvedModule left, ResolvedModule right) {
+                return left.root.compareTo(right.root);
+            }
+        });
+        List<ModuleReadinessDecision> decisions =
+                new ArrayList<ModuleReadinessDecision>();
+        for (ResolvedModule build : ordered) {
+            List<ModuleReadinessEvidence> blockers = evidenceFor(build);
+            if (build.ambiguity != null) {
+                blockers.add(build.ambiguity);
+                sortEvidence(blockers);
+            }
+            if (blockers.isEmpty()) {
+                eligibilityByRoot.put(build.root, true);
+                decisions.add(ModuleReadinessDecision.eligible(
+                        displayRoot(build.root), build.buildSystem, build.buildPath));
+                continue;
+            }
+            eligibilityByRoot.put(build.root, false);
+            if (build.anchorId != null) {
+                markers.put(build.anchorId, "REFUSED [MODULE_REFUSED]: " + blockers.size() +
+                        (blockers.size() == 1 ? " blocker" : " blockers") +
+                        "; no module changes were applied");
+            }
+            for (ModuleReadinessEvidence blocker : blockers) {
+                decisions.add(ModuleReadinessDecision.refused(
+                        displayRoot(build.root), build.buildSystem, blocker));
+            }
+        }
+        planned = Collections.unmodifiableList(decisions);
+        return planned;
+    }
+
+    private void recordIncompleteReactors() {
+        for (ExpectedModule expected : expectedModules) {
+            List<ModuleBuild> childBuilds = builds.get(expected.expectedRoot);
+            boolean compatible = false;
+            if (childBuilds != null) {
+                for (ModuleBuild childBuild : childBuilds) {
+                    if (("MAVEN".equals(expected.buildSystem) &&
+                            "MAVEN".equals(childBuild.buildSystem)) ||
+                            ("GRADLE".equals(expected.buildSystem) &&
+                                    childBuild.buildSystem.startsWith("GRADLE_"))) {
+                        compatible = true;
+                        break;
+                    }
+                }
+            }
+            if (!compatible) {
+                boolean mismatch = childBuilds != null && !childBuilds.isEmpty();
+                recordEvidence(new ModuleReadinessEvidence(
+                        expected.declarationPath, expected.buildSystem,
+                        "Incomplete reactor topology", expected.notation,
+                        mismatch ? "MODULE_REACTOR_BUILD_MISMATCH" :
+                                "MODULE_INCOMPLETE_REACTOR",
+                        mismatch ?
+                                "A declared child is owned only by an incompatible build system" :
+                                "A declared child module build root is absent from the supplied sources",
+                        mismatch ?
+                                "Supply the child descriptor required by the declaring reactor" :
+                                "Supply every declared child build descriptor before module migration",
+                        expected.markerId, true));
+            }
+        }
+    }
+
+    synchronized String markerDescription(UUID id) {
+        if (planned == null) {
+            throw new IllegalStateException("Module readiness plan must be frozen before apply");
+        }
+        return markers.get(id);
+    }
+
+    synchronized boolean isEligibleSourcePath(String sourcePath) {
+        if (planned == null) {
+            throw new IllegalStateException("Module readiness plan must be frozen before apply");
+        }
+        String normalized = normalize(java.nio.file.Paths.get(sourcePath));
+        String owner = ownerRoot(normalized);
+        if (owner == null) {
+            owner = inferArtifactRoot(normalized);
+        }
+        return Boolean.TRUE.equals(eligibilityByRoot.get(owner));
+    }
+
+    private List<ModuleReadinessEvidence> evidenceFor(ResolvedModule module) {
+        List<ModuleReadinessEvidence> owned = new ArrayList<ModuleReadinessEvidence>();
+        for (ModuleReadinessEvidence finding : evidence.values()) {
+            if (ModuleReadinessEvidence.ALL_MODULES.equals(finding.sourcePath)) {
+                owned.add(finding.atSourcePath(module.buildPath));
+                continue;
+            }
+            String owner = ownerRoot(finding.sourcePath);
+            if (module.root.equals(owner) ||
+                    ("UNRESOLVED".equals(module.buildSystem) && owner == null &&
+                            module.root.equals(inferArtifactRoot(finding.sourcePath)))) {
+                owned.add(finding);
+            }
+        }
+        sortEvidence(owned);
+        return owned;
+    }
+
+    private static void sortEvidence(List<ModuleReadinessEvidence> evidence) {
+        Collections.sort(evidence, new Comparator<ModuleReadinessEvidence>() {
+            @Override
+            public int compare(ModuleReadinessEvidence left, ModuleReadinessEvidence right) {
+                int path = left.sourcePath.compareTo(right.sourcePath);
+                if (path != 0) {
+                    return path;
+                }
+                int reason = left.reasonCode.compareTo(right.reasonCode);
+                if (reason != 0) {
+                    return reason;
+                }
+                int construct = left.construct.compareTo(right.construct);
+                return construct != 0 ? construct :
+                        left.occurrenceKey().compareTo(right.occurrenceKey());
+            }
+        });
+    }
+
+    private static ResolvedModule resolve(String root, List<ModuleBuild> descriptors) {
+        List<ModuleBuild> ordered = new ArrayList<ModuleBuild>(descriptors);
+        Collections.sort(ordered, new Comparator<ModuleBuild>() {
+            @Override
+            public int compare(ModuleBuild left, ModuleBuild right) {
+                int mavenFirst = buildPriority(left.buildSystem) -
+                                 buildPriority(right.buildSystem);
+                return mavenFirst != 0 ? mavenFirst :
+                        left.buildPath.compareTo(right.buildPath);
+            }
+        });
+        ModuleBuild anchor = ordered.get(0);
+        if (ordered.size() == 1) {
+            return new ResolvedModule(root, anchor.buildPath, anchor.buildSystem,
+                    anchor.anchorId, null);
+        }
+        List<String> systems = new ArrayList<String>();
+        for (ModuleBuild descriptor : ordered) {
+            if (!systems.contains(descriptor.buildSystem)) {
+                systems.add(descriptor.buildSystem);
+            }
+        }
+        String construct = String.join("+", systems);
+        ModuleReadinessEvidence ambiguity = new ModuleReadinessEvidence(
+                anchor.buildPath, "MODULE_TOPOLOGY", "Module build topology", construct,
+                "MODULE_BUILD_ROOT_AMBIGUOUS",
+                "More than one build descriptor claims the same module root",
+                "Select one authoritative build descriptor before module migration",
+                null, false);
+        return new ResolvedModule(root, anchor.buildPath, "AMBIGUOUS",
+                anchor.anchorId, ambiguity);
+    }
+
+    private static int buildPriority(String buildSystem) {
+        if ("MAVEN".equals(buildSystem)) {
+            return 0;
+        }
+        if ("GRADLE_GROOVY".equals(buildSystem)) {
+            return 1;
+        }
+        return 2;
+    }
+
+    private String ownerRoot(String sourcePath) {
+        String owner = null;
+        for (String root : builds.keySet()) {
+            if (owns(root, sourcePath) && (owner == null || root.length() > owner.length())) {
+                owner = root;
+            }
+        }
+        return owner;
+    }
+
+    private Map<String, List<ModuleArtifact>> orphanGroups() {
+        Map<String, List<ModuleArtifact>> groups =
+                new LinkedHashMap<String, List<ModuleArtifact>>();
+        for (ModuleArtifact artifact : artifacts.values()) {
+            if (ownerRoot(artifact.path) != null) {
+                continue;
+            }
+            String root = inferArtifactRoot(artifact.path);
+            List<ModuleArtifact> group = groups.get(root);
+            if (group == null) {
+                group = new ArrayList<ModuleArtifact>();
+                groups.put(root, group);
+            }
+            group.add(artifact);
+        }
+        return groups;
+    }
+
+    private static ModuleArtifact safeAnchor(List<ModuleArtifact> artifacts) {
+        for (ModuleArtifact artifact : artifacts) {
+            if (artifact.markerSafe) {
+                return artifact;
+            }
+        }
+        return null;
+    }
+
+    private static String inferArtifactRoot(String sourcePath) {
+        int source = sourcePath.indexOf("/src/");
+        if (source >= 0) {
+            return sourcePath.substring(0, source);
+        }
+        if (sourcePath.startsWith("src/")) {
+            return "";
+        }
+        return parent(sourcePath);
+    }
+
+    private static boolean owns(String root, String sourcePath) {
+        return root.isEmpty() || sourcePath.equals(root) || sourcePath.startsWith(root + '/');
+    }
+
+    static String normalize(Path path) {
+        return path.normalize().toString().replace(File.separatorChar, '/');
+    }
+
+    static String javaSourceKind(String sourcePath) {
+        String[] segments = sourcePath.split("/");
+        for (int i = 0; i + 2 < segments.length; i++) {
+            if (!"src".equals(segments[i]) || !"java".equals(segments[i + 2])) {
+                continue;
+            }
+            String sourceSet = segments[i + 1].toLowerCase(java.util.Locale.ROOT);
+            if ("main".equals(sourceSet)) {
+                return "JAVA_MAIN";
+            }
+            if (sourceSet.contains("test") || "it".equals(sourceSet) ||
+                    sourceSet.contains("integration") || sourceSet.contains("acceptance")) {
+                return "JAVA_TEST";
+            }
+            return "JAVA_SOURCE";
+        }
+        return "JAVA_SOURCE";
+    }
+
+    private static String parent(String path) {
+        int separator = path.lastIndexOf('/');
+        return separator < 0 ? "" : path.substring(0, separator);
+    }
+
+    private static String displayRoot(String root) {
+        return root.isEmpty() ? "." : root;
+    }
+
+    private static final class ModuleBuild {
+        private final String root;
+        private final String buildPath;
+        private final String buildSystem;
+        private final UUID anchorId;
+
+        private ModuleBuild(String root, String buildPath, String buildSystem, UUID anchorId) {
+            this.root = root;
+            this.buildPath = buildPath;
+            this.buildSystem = buildSystem;
+            this.anchorId = anchorId;
+        }
+    }
+
+    private static final class ModuleArtifact {
+        private final String path;
+        private final UUID id;
+        private final boolean markerSafe;
+
+        private ModuleArtifact(String path, UUID id, boolean markerSafe) {
+            this.path = path;
+            this.id = id;
+            this.markerSafe = markerSafe;
+        }
+    }
+
+    private static final class ExpectedModule {
+        private final String declarationPath;
+        private final String expectedRoot;
+        private final String notation;
+        private final UUID markerId;
+        private final String buildSystem;
+
+        private ExpectedModule(String declarationPath, String expectedRoot,
+                               String notation, UUID markerId, String buildSystem) {
+            this.declarationPath = declarationPath;
+            this.expectedRoot = expectedRoot;
+            this.notation = notation;
+            this.markerId = markerId;
+            this.buildSystem = buildSystem;
+        }
+    }
+
+    private static final class ResolvedModule {
+        private final String root;
+        private final String buildPath;
+        private final String buildSystem;
+        private final UUID anchorId;
+        private final ModuleReadinessEvidence ambiguity;
+
+        private ResolvedModule(String root, String buildPath, String buildSystem,
+                               UUID anchorId, ModuleReadinessEvidence ambiguity) {
+            this.root = root;
+            this.buildPath = buildPath;
+            this.buildSystem = buildSystem;
+            this.anchorId = anchorId;
+            this.ambiguity = ambiguity;
+        }
+    }
+}

--- a/src/main/java/io/github/devanshops/rewrite/helidon/table/ModuleMigrationReadinessTable.java
+++ b/src/main/java/io/github/devanshops/rewrite/helidon/table/ModuleMigrationReadinessTable.java
@@ -1,0 +1,123 @@
+package io.github.devanshops.rewrite.helidon.table;
+
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+/** Module-scoped eligibility and refusal evidence for the conservative migration profile. */
+public final class ModuleMigrationReadinessTable
+        extends DataTable<ModuleMigrationReadinessTable.Row> {
+
+    public ModuleMigrationReadinessTable(Recipe recipe) {
+        super(recipe,
+                "Spring Boot module migration eligibility",
+                "Read-only, module-scoped eligibility evidence for a documented migration " +
+                "profile. Eligibility is not a runtime-readiness certification.");
+    }
+
+    public static final class Row {
+        @Column(displayName = "Module path",
+                description = "Normalized project-relative root of the owning build module.")
+        private final String modulePath;
+
+        @Column(displayName = "Build system",
+                description = "Resolved build system for the owning module.")
+        private final String buildSystem;
+
+        @Column(displayName = "Profile",
+                description = "Stable migration profile against which eligibility was assessed.")
+        private final String profile;
+
+        @Column(displayName = "Outcome",
+                description = "ELIGIBLE_FOR_PROFILE or REFUSED for the complete supplied module.")
+        private final String outcome;
+
+        @Column(displayName = "Source path",
+                description = "Project-relative path containing the evidence or module anchor.")
+        private final String sourcePath;
+
+        @Column(displayName = "Source kind",
+                description = "Artifact or source-set kind containing the evidence.")
+        private final String sourceKind;
+
+        @Column(displayName = "Feature",
+                description = "Migration feature family represented by the evidence.")
+        private final String feature;
+
+        @Column(displayName = "Construct",
+                description = "Build, source, resource, or metadata construct; values are omitted.")
+        private final String construct;
+
+        @Column(displayName = "Reason code",
+                description = "Stable machine-readable eligibility or refusal reason.")
+        private final String reasonCode;
+
+        @Column(displayName = "Reason",
+                description = "Human-readable explanation of the module outcome.")
+        private final String reason;
+
+        @Column(displayName = "Suggested direction",
+                description = "Suggested bounded recipe or manual next step.")
+        private final String suggestedDirection;
+
+        public Row(String modulePath, String buildSystem, String profile, String outcome,
+                   String sourcePath, String sourceKind, String feature, String construct,
+                   String reasonCode, String reason, String suggestedDirection) {
+            this.modulePath = modulePath;
+            this.buildSystem = buildSystem;
+            this.profile = profile;
+            this.outcome = outcome;
+            this.sourcePath = sourcePath;
+            this.sourceKind = sourceKind;
+            this.feature = feature;
+            this.construct = construct;
+            this.reasonCode = reasonCode;
+            this.reason = reason;
+            this.suggestedDirection = suggestedDirection;
+        }
+
+        public String getModulePath() {
+            return modulePath;
+        }
+
+        public String getBuildSystem() {
+            return buildSystem;
+        }
+
+        public String getProfile() {
+            return profile;
+        }
+
+        public String getOutcome() {
+            return outcome;
+        }
+
+        public String getSourcePath() {
+            return sourcePath;
+        }
+
+        public String getSourceKind() {
+            return sourceKind;
+        }
+
+        public String getFeature() {
+            return feature;
+        }
+
+        public String getConstruct() {
+            return construct;
+        }
+
+        public String getReasonCode() {
+            return reasonCode;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
+        public String getSuggestedDirection() {
+            return suggestedDirection;
+        }
+    }
+}

--- a/src/test/java/io/github/devanshops/rewrite/helidon/AssessSpringBootModuleMigrationReadinessTest.java
+++ b/src/test/java/io/github/devanshops/rewrite/helidon/AssessSpringBootModuleMigrationReadinessTest.java
@@ -1,0 +1,2277 @@
+package io.github.devanshops.rewrite.helidon;
+
+import io.github.devanshops.rewrite.helidon.table.ModuleMigrationReadinessTable;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.EncodingDetectingInputStream;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.SourceSpecs;
+import org.openrewrite.test.TypeValidation;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.tree.ParseError;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.buildGradleKts;
+import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.test.SourceSpecs.other;
+import static org.openrewrite.test.SourceSpecs.text;
+import static org.openrewrite.xml.Assertions.xml;
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class AssessSpringBootModuleMigrationReadinessTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AssessSpringBootModuleMigrationReadiness())
+                .parser(JavaParser.fromJavaVersion().classpath(
+                        "spring-context", "spring-beans", "spring-core", "spring-tx",
+                        "spring-boot", "spring-boot-autoconfigure"))
+                .cycles(2);
+    }
+
+    @Test
+    void reportsACleanMavenModuleEligibleForTheConservativeProfile() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row -> {
+                      assertThat(row.getModulePath()).isEqualTo("orders");
+                      assertThat(row.getBuildSystem()).isEqualTo("MAVEN");
+                      assertThat(row.getProfile()).isEqualTo("HELIDON_MP_CONSERVATIVE");
+                      assertThat(row.getOutcome()).isEqualTo("ELIGIBLE_FOR_PROFILE");
+                      assertThat(row.getReasonCode()).isEqualTo("MODULE_ELIGIBLE_FOR_PROFILE");
+                  })),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          java(
+            """
+              package com.example.orders;
+
+              class OrderService {
+                  String find() { return "order"; }
+              }
+              """,
+            source -> source.path(
+                    "orders/src/main/java/com/example/orders/OrderService.java"))
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void refusesAttributedSpringJavaResidueWithoutChangingModuleSemantics() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(1)
+                  .dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row -> {
+                      assertThat(row.getModulePath()).isEqualTo("orders");
+                      assertThat(row.getOutcome()).isEqualTo("REFUSED");
+                      assertThat(row.getSourcePath()).isEqualTo(
+                              "orders/src/main/java/com/example/orders/OrderService.java");
+                      assertThat(row.getSourceKind()).isEqualTo("JAVA_MAIN");
+                      assertThat(row.getConstruct()).isEqualTo(
+                              "org.springframework.context.ApplicationContext");
+                      assertThat(row.getReasonCode()).isEqualTo("MODULE_SPRING_JAVA_RESIDUE");
+                  })),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          java(
+            """
+              package com.example.orders;
+
+              import org.springframework.context.ApplicationContext;
+
+              class OrderService {
+                  ApplicationContext context;
+              }
+              """,
+            source -> source.path(
+                    "orders/src/main/java/com/example/orders/OrderService.java"))
+        );
+    }
+
+    @Test
+    void reportsEveryAttributedJavaBlockerInDeterministicSourceOrder() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getSourcePath,
+                                  ModuleMigrationReadinessTable.Row::getSourceKind,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("orders/src/integrationTest/java/com/example/orders/OrderFlowTest.java",
+                                          "JAVA_TEST",
+                                          "org.springframework.context.ApplicationContext",
+                                          "MODULE_SPRING_JAVA_RESIDUE"),
+                                  tuple("orders/src/main/java/com/example/orders/OrderService.java",
+                                          "JAVA_MAIN",
+                                          "org.springframework.context.ApplicationContext",
+                                          "MODULE_SPRING_JAVA_RESIDUE"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          java(
+            """
+              package com.example.orders;
+
+              import org.springframework.context.ApplicationContext;
+
+              class OrderService {
+                  ApplicationContext context;
+              }
+              """,
+            source -> source.path(
+                    "orders/src/main/java/com/example/orders/OrderService.java")),
+          java(
+            """
+              package com.example.orders;
+
+              class OrderFlowTest {
+                  org.springframework.context.ApplicationContext context;
+              }
+              """,
+            source -> source.path(
+                    "orders/src/integrationTest/java/com/example/orders/OrderFlowTest.java"))
+        );
+    }
+
+    @Test
+    void refusesSpringMavenBuildResidueAtTheModuleAnchorAndExactCoordinate() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row -> {
+                      assertThat(row.getModulePath()).isEqualTo("orders");
+                      assertThat(row.getBuildSystem()).isEqualTo("MAVEN");
+                      assertThat(row.getOutcome()).isEqualTo("REFUSED");
+                      assertThat(row.getSourcePath()).isEqualTo("orders/pom.xml");
+                      assertThat(row.getSourceKind()).isEqualTo("MAVEN");
+                      assertThat(row.getConstruct()).isEqualTo(
+                              "org.springframework:spring-context");
+                      assertThat(row.getReasonCode()).isEqualTo("MODULE_SPRING_BUILD_RESIDUE");
+                  })),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework</groupId>
+                          <artifactId>spring-context</artifactId>
+                          <version>7.0.8</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework</groupId>
+                          <artifactId>spring-context</artifactId>
+                          <version>7.0.8</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml"))
+        );
+    }
+
+    @Test
+    void reportsSensitiveResourceBlockersWithoutMarkingOrLeakingTheirValues() {
+        String secret = "SPRING_SENTINEL_SECRET_18f4";
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows -> {
+              assertThat(rows)
+                      .extracting(ModuleMigrationReadinessTable.Row::getSourcePath,
+                              ModuleMigrationReadinessTable.Row::getSourceKind,
+                              ModuleMigrationReadinessTable.Row::getConstruct,
+                              ModuleMigrationReadinessTable.Row::getReasonCode)
+                      .containsExactly(
+                              tuple("orders/src/main/resources/META-INF/spring.factories",
+                                      "SPRING_FACTORIES", "org.springframework.boot.autoconfigure.EnableAutoConfiguration",
+                                      "MODULE_SPRING_METADATA"),
+                              tuple("orders/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+                                      "SPRING_AUTOCONFIG_IMPORTS", "AutoConfiguration.imports entry",
+                                      "MODULE_SPRING_METADATA"),
+                              tuple("orders/src/main/resources/application.properties",
+                                      "SPRING_PROPERTIES", "spring.datasource.password",
+                                      "MODULE_SPRING_CONFIGURATION"),
+                              tuple("orders/src/main/resources/application.yml",
+                                      "SPRING_YAML", "spring.datasource.password",
+                                      "MODULE_SPRING_CONFIGURATION"),
+                              tuple("orders/src/main/resources/spring-context.xml",
+                                      "SPRING_XML", "Spring XML namespace",
+                                      "MODULE_SPRING_XML"));
+              assertThat(rows).allSatisfy(row ->
+                      assertThat(String.join("|", row.getSourcePath(), row.getSourceKind(),
+                              row.getFeature(), row.getConstruct(), row.getReasonCode(),
+                              row.getReason(), row.getSuggestedDirection()))
+                              .doesNotContain(secret));
+          }),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 5 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          properties(
+            """
+              spring.datasource.password=SPRING_SENTINEL_SECRET_18f4
+              """,
+            source -> source.path("orders/src/main/resources/application.properties")),
+          yaml(
+            """
+              spring:
+                datasource:
+                  password: SPRING_SENTINEL_SECRET_18f4
+              """,
+            source -> source.path("orders/src/main/resources/application.yml")),
+          xml(
+            """
+              <beans xmlns="http://www.springframework.org/schema/beans">
+                  <property name="password" value="SPRING_SENTINEL_SECRET_18f4"/>
+              </beans>
+              """,
+            source -> source.path("orders/src/main/resources/spring-context.xml")),
+          properties(
+            """
+              org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.example.SPRING_SENTINEL_SECRET_18f4
+              """,
+            source -> source.path("orders/src/main/resources/META-INF/spring.factories")),
+          text(
+            """
+              com.example.SPRING_SENTINEL_SECRET_18f4
+              """,
+            source -> source.path("orders/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"))
+        );
+    }
+
+    @Test
+    void refusesEveryNonEmptyApplicationConfigurationKeyWithoutReportingValues() {
+        String secret = "APPLICATION_SENTINEL_91ac";
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows -> {
+              assertThat(rows)
+                      .extracting(ModuleMigrationReadinessTable.Row::getSourcePath,
+                              ModuleMigrationReadinessTable.Row::getConstruct,
+                              ModuleMigrationReadinessTable.Row::getReasonCode)
+                      .containsExactly(
+                              tuple("orders/src/main/resources/application-prod.properties",
+                                      "custom.api-token", "MODULE_APPLICATION_CONFIGURATION"),
+                              tuple("orders/src/main/resources/application-prod.properties",
+                                      "management.endpoints.web.exposure.include",
+                                      "MODULE_APPLICATION_CONFIGURATION"),
+                              tuple("orders/src/main/resources/application-prod.properties",
+                                      "server.port", "MODULE_APPLICATION_CONFIGURATION"),
+                              tuple("orders/src/main/resources/application.yml",
+                                      "custom.token", "MODULE_APPLICATION_CONFIGURATION"));
+              assertThat(rows).allSatisfy(row ->
+                      assertThat(String.join("|", row.getConstruct(), row.getReason(),
+                              row.getSuggestedDirection())).doesNotContain(secret));
+          }),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 4 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          properties(
+            """
+              server.port=8080
+              management.endpoints.web.exposure.include=health
+              custom.api-token=APPLICATION_SENTINEL_91ac
+              """,
+            source -> source.path(
+                    "orders/src/main/resources/application-prod.properties")),
+          yaml(
+            """
+              custom:
+                token: APPLICATION_SENTINEL_91ac
+              """,
+            source -> source.path("orders/src/main/resources/application.yml"))
+        );
+    }
+
+    @Test
+    void refusesSpringNamespaceDeclaredBelowANeutralXmlRootWithoutMarkingXml() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row -> {
+                      assertThat(row.getSourceKind()).isEqualTo("SPRING_XML");
+                      assertThat(row.getConstruct()).isEqualTo("Spring XML namespace");
+                      assertThat(row.getReasonCode()).isEqualTo("MODULE_SPRING_XML");
+                  })),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          xml(
+            """
+              <configuration>
+                  <wiring xmlns:beans="http://www.springframework.org/schema/beans">
+                      <beans:bean id="secret" class="com.example.PrivateValue"/>
+                  </wiring>
+              </configuration>
+              """,
+            source -> source.path("orders/src/main/resources/wiring.xml"))
+        );
+    }
+
+    @Test
+    void assignsEvidenceToTheDeepestMavenRootWithoutRefusingParentOrSibling() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getOutcome,
+                                  ModuleMigrationReadinessTable.Row::getSourcePath,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple(".", "ELIGIBLE_FOR_PROFILE", "pom.xml",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("services/billing", "ELIGIBLE_FOR_PROFILE",
+                                          "services/billing/pom.xml",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("services/orders", "REFUSED",
+                                          "services/orders/src/main/java/com/example/Orders.java",
+                                          "MODULE_SPRING_JAVA_RESIDUE"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>reactor</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("pom.xml")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>billing</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("services/billing/pom.xml")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("services/orders/pom.xml")),
+          java(
+            """
+              package com.example;
+
+              import org.springframework.context.ApplicationContext;
+
+              class Orders {
+                  ApplicationContext context;
+              }
+              """,
+            source -> source.path("services/orders/src/main/java/com/example/Orders.java"))
+        );
+    }
+
+    @Test
+    void reportsACleanGroovyGradleModuleEligibleForTheConservativeProfile() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row -> {
+                      assertThat(row.getModulePath()).isEqualTo("orders");
+                      assertThat(row.getBuildSystem()).isEqualTo("GRADLE_GROOVY");
+                      assertThat(row.getOutcome()).isEqualTo("ELIGIBLE_FOR_PROFILE");
+                      assertThat(row.getSourcePath()).isEqualTo("orders/build.gradle");
+                  })),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            source -> source.path("orders/build.gradle"))
+        );
+    }
+
+    @Test
+    void refusesMavenAndGradleDescriptorsAtTheSameModuleRoot() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row -> {
+                      assertThat(row.getModulePath()).isEqualTo("orders");
+                      assertThat(row.getBuildSystem()).isEqualTo("AMBIGUOUS");
+                      assertThat(row.getOutcome()).isEqualTo("REFUSED");
+                      assertThat(row.getSourcePath()).isEqualTo("orders/pom.xml");
+                      assertThat(row.getSourceKind()).isEqualTo("MODULE_TOPOLOGY");
+                      assertThat(row.getConstruct()).isEqualTo("MAVEN+GRADLE_GROOVY");
+                      assertThat(row.getReasonCode()).isEqualTo(
+                              "MODULE_BUILD_ROOT_AMBIGUOUS");
+                  })),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            source -> source.path("orders/build.gradle"))
+        );
+    }
+
+    @Test
+    void refusesBuildlessSpringArtifactsInsteadOfDroppingTheirEvidence() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getBuildSystem,
+                                  ModuleMigrationReadinessTable.Row::getSourcePath,
+                                  ModuleMigrationReadinessTable.Row::getSourceKind,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("orders", "UNRESOLVED",
+                                          "orders/src/main/java/com/example/Orders.java",
+                                          "MODULE_TOPOLOGY", "MODULE_BUILD_ROOT_MISSING"),
+                                  tuple("orders", "UNRESOLVED",
+                                          "orders/src/main/java/com/example/Orders.java",
+                                          "JAVA_MAIN", "MODULE_SPRING_JAVA_RESIDUE"))),
+          java(
+            """
+              package com.example;
+
+              import org.springframework.context.ApplicationContext;
+
+              class Orders {
+                  ApplicationContext context;
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/package com.example;
+
+              import org.springframework.context.ApplicationContext;
+
+              class Orders {
+                  ApplicationContext context;
+              }
+              """,
+            source -> source.path("orders/src/main/java/com/example/Orders.java"))
+        );
+    }
+
+    @Test
+    void assignsEvidenceToADeepestKotlinGradleChildOfAMavenRoot() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getBuildSystem,
+                                  ModuleMigrationReadinessTable.Row::getOutcome,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple(".", "MAVEN", "ELIGIBLE_FOR_PROFILE",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("orders", "GRADLE_KOTLIN", "REFUSED",
+                                          "MODULE_SPRING_JAVA_RESIDUE"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>reactor</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("pom.xml")),
+          buildGradleKts(
+            """
+              plugins {
+                  java
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins {
+                  java
+              }
+              """,
+            source -> source.path("orders/build.gradle.kts")),
+          java(
+            """
+              package com.example;
+
+              import org.springframework.context.ApplicationContext;
+
+              class Orders {
+                  ApplicationContext context;
+              }
+              """,
+            source -> source.path("orders/src/main/java/com/example/Orders.java"))
+        );
+    }
+
+    @Test
+    void refusesEveryLiteralSpringGradleBuildResidue() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getBuildSystem,
+                                  ModuleMigrationReadinessTable.Row::getSourceKind,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("GRADLE_GROOVY", "GRADLE_GROOVY",
+                                          "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("GRADLE_GROOVY", "GRADLE_GROOVY",
+                                          "org.springframework:spring-context",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradle(
+            """
+              plugins {
+                  id 'com.example.safe' version '1.0.0'
+                  id 'org.springframework.boot' version '4.0.0'
+              }
+
+              dependencies {
+                  implementation 'org.springframework:spring-context:7.0.8'
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/plugins {
+                  id 'com.example.safe' version '1.0.0'
+                  id 'org.springframework.boot' version '4.0.0'
+              }
+
+              dependencies {
+                  implementation 'org.springframework:spring-context:7.0.8'
+              }
+              """,
+            source -> source.path("orders/build.gradle"))
+        );
+    }
+
+    @Test
+    void refusesUnresolvedMavenAndGradleDeclarationsThatCanHideSpringBuildResidue() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("catalog", "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("orders", "Unresolved Maven coordinate",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"))),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              def springCoordinate = providers.gradleProperty('springCoordinate')
+
+              dependencies {
+                  implementation springCoordinate
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins {
+                  id 'java'
+              }
+
+              def springCoordinate = providers.gradleProperty('springCoordinate')
+
+              dependencies {
+                  implementation springCoordinate
+              }
+              """,
+            source -> source.path("catalog/build.gradle")),
+          xml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>${spring.group}</groupId>
+                          <artifactId>spring-context</artifactId>
+                          <version>7.0.8</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>${spring.group}</groupId>
+                          <artifactId>spring-context</artifactId>
+                          <version>7.0.8</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml"))
+        );
+    }
+
+    @Test
+    void refusesExactSpringSyntaxWhenTypeAttributionIsMissing() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion())
+                  .typeValidationOptions(TypeValidation.none())
+                  .dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                          assertThat(rows)
+                                  .extracting(ModuleMigrationReadinessTable.Row::getSourcePath,
+                                          ModuleMigrationReadinessTable.Row::getConstruct,
+                                          ModuleMigrationReadinessTable.Row::getReasonCode)
+                                  .containsExactly(
+                                          tuple("orders/src/main/java/com/example/Imported.java",
+                                                  "org.springframework.missing.Unavailable",
+                                                  "MODULE_MISSING_ATTRIBUTION"),
+                                          tuple("orders/src/main/java/com/example/Qualified.java",
+                                                  "org.springframework.missing.Unavailable",
+                                                  "MODULE_MISSING_ATTRIBUTION"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          java(
+            """
+              package com.example;
+
+              import org.springframework.missing.Unavailable;
+
+              class Imported {
+                  Unavailable value;
+              }
+              """,
+            source -> source.path("orders/src/main/java/com/example/Imported.java")),
+          java(
+            """
+              package com.example;
+
+              class Qualified {
+                  org.springframework.missing.Unavailable value;
+              }
+              """,
+            source -> source.path("orders/src/main/java/com/example/Qualified.java"))
+        );
+    }
+
+    @Test
+    void preservesIdenticalConfigurationOccurrencesAsSeparateRows() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("spring.duplicate", "MODULE_SPRING_CONFIGURATION"),
+                                  tuple("spring.duplicate", "MODULE_SPRING_CONFIGURATION"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          properties(
+            """
+              spring.duplicate=first
+              spring.duplicate=second
+              """,
+            source -> source.path("orders/src/main/resources/application.properties"))
+        );
+    }
+
+    @Test
+    void refusesUnsupportedKotlinAndGroovyApplicationSources() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getSourceKind,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("GROOVY_SOURCE", "MODULE_UNSUPPORTED_SOURCE_LANGUAGE"),
+                                  tuple("KOTLIN_SOURCE", "MODULE_UNSUPPORTED_SOURCE_LANGUAGE"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          groovy(
+            """
+              package com.example
+
+              class GroovyOrderService {
+              }
+              """,
+            source -> source.path(
+                    "orders/src/main/groovy/com/example/GroovyOrderService.groovy")),
+          kotlin(
+            """
+              package com.example
+
+              class KotlinOrderService
+              """,
+            source -> source.path(
+                    "orders/src/main/kotlin/com/example/KotlinOrderService.kt"))
+        );
+    }
+
+    @Test
+    void refusesPlainUnparsedMavenAndGradleBuildDescriptors() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getBuildSystem,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("catalog", "GRADLE_GROOVY",
+                                          "MODULE_BUILD_DESCRIPTOR_UNPARSED"),
+                                  tuple("orders", "MAVEN",
+                                          "MODULE_BUILD_DESCRIPTOR_UNPARSED"))),
+          text(
+            "not a Gradle AST",
+            "~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>not a Gradle AST",
+            source -> source.path("catalog/build.gradle")),
+          text(
+            "not a Maven AST",
+            "~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>not a Maven AST",
+            source -> source.path("orders/pom.xml"))
+        );
+    }
+
+    @Test
+    void refusesLiteralAndUnresolvedSpringGradleFormsAcrossDslShapes() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("catalog", "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("catalog", "org.springframework:spring-context",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("orders", "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("orders", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("orders", "org.springframework.boot:spring-boot-devtools",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradleKts(
+            """
+              plugins {
+                  java
+                  alias(libs.plugins.spring.boot)
+              }
+
+              dependencies {
+                  customConfiguration("org.springframework:spring-context:7.0.8")
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/plugins {
+                  java
+                  alias(libs.plugins.spring.boot)
+              }
+
+              dependencies {
+                  customConfiguration("org.springframework:spring-context:7.0.8")
+              }
+              """,
+            source -> source.path("catalog/build.gradle.kts")),
+          buildGradle(
+            """
+              apply plugin: 'org.springframework.boot'
+
+              plugins {
+                  alias libs.plugins.spring.boot
+              }
+
+              dependencies {
+                  developmentOnly 'org.springframework.boot:spring-boot-devtools:4.0.0'
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 3 blockers; no module changes were applied)~~>*/apply plugin: 'org.springframework.boot'
+
+              plugins {
+                  alias libs.plugins.spring.boot
+              }
+
+              dependencies {
+                  developmentOnly 'org.springframework.boot:spring-boot-devtools:4.0.0'
+              }
+              """,
+            source -> source.path("orders/build.gradle"))
+        );
+    }
+
+    @Test
+    void refusesMissingMavenAndGradleReactorChildren() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getSourceKind,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("gradle-parent", "GRADLE", ":child",
+                                          "MODULE_INCOMPLETE_REACTOR"),
+                                  tuple("maven-parent", "MAVEN", "child",
+                                          "MODULE_INCOMPLETE_REACTOR"))),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins {
+                  id 'java'
+              }
+              """,
+            source -> source.path("gradle-parent/build.gradle")),
+          groovy(
+            """
+              include ':child'
+              """,
+            source -> source.path("gradle-parent/settings.gradle")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                      <module>child</module>
+                  </modules>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                      <module>child</module>
+                  </modules>
+              </project>
+              """,
+            source -> source.path("maven-parent/pom.xml"))
+        );
+    }
+
+    @Test
+    void acceptsCompleteSuppliedMavenAndGradleReactorChildren() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getOutcome)
+                          .containsExactly(
+                                  tuple("gradle-parent", "ELIGIBLE_FOR_PROFILE"),
+                                  tuple("gradle-parent/child", "ELIGIBLE_FOR_PROFILE"),
+                                  tuple("maven-parent", "ELIGIBLE_FOR_PROFILE"),
+                                  tuple("maven-parent/child", "ELIGIBLE_FOR_PROFILE"))),
+          buildGradle("plugins { id 'java' }",
+                  source -> source.path("gradle-parent/build.gradle")),
+          groovy("include ':child'",
+                  source -> source.path("gradle-parent/settings.gradle")),
+          buildGradle("plugins { id 'java' }",
+                  source -> source.path("gradle-parent/child/build.gradle")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>child</module></modules>
+              </project>
+              """,
+            source -> source.path("maven-parent/pom.xml")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>child</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("maven-parent/child/pom.xml"))
+        );
+    }
+
+    @Test
+    void refusesMavenMarkerAndSuppliedPathDisagreement() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row ->
+                          assertThat(row.getReasonCode()).isEqualTo(
+                                  "MODULE_OWNERSHIP_DISAGREEMENT"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml").mapBeforeRecipe(document -> {
+                MavenResolutionResult resolution = document.getMarkers()
+                        .findFirst(MavenResolutionResult.class).orElseThrow();
+                MavenResolutionResult changed = resolution.withPom(
+                        resolution.getPom().withRequested(
+                                resolution.getPom().getRequested().withSourcePath(
+                                        Paths.get("elsewhere/pom.xml"))));
+                return document.withMarkers(document.getMarkers().setByType(changed));
+            }))
+        );
+    }
+
+    @Test
+    void refusesRecognizedEvidenceArtifactsWhenTheyWereNotParsed() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getSourcePath,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("orders/src/main/java/com/example/Broken.java",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"),
+                                  tuple("orders/src/main/resources/META-INF/spring.factories",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"),
+                                  tuple("orders/src/main/resources/application.properties",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"),
+                                  tuple("orders/src/main/resources/application.yml",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"),
+                                  tuple("orders/src/main/resources/broken-context.xml",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"),
+                                  tuple("orders/src/main/resources/spring-context.xml",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 6 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          text("class Broken {",
+                  source -> source.path(
+                          "orders/src/main/java/com/example/Broken.java")),
+          text("broken=factory",
+                  source -> source.path(
+                          "orders/src/main/resources/META-INF/spring.factories")),
+          text("server.port=8080",
+                  source -> source.path(
+                          "orders/src/main/resources/application.properties")),
+          text("spring: [",
+                  source -> source.path(
+                          "orders/src/main/resources/application.yml")),
+          parseError("<beans>",
+                  source -> source.path(
+                                  "orders/src/main/resources/broken-context.xml")
+                          .beforeRecipeParseError(error -> { })),
+          text("<beans",
+                  source -> source.path(
+                          "orders/src/main/resources/spring-context.xml"))
+        );
+    }
+
+    @Test
+    void refusesUnparsedGradleSettingsAndAutoConfigurationMetadataModels() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getSourcePath,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("groovy-settings", "groovy-settings/settings.gradle",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"),
+                                  tuple("kotlin-settings", "kotlin-settings/settings.gradle.kts",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"),
+                                  tuple("metadata",
+                                          "metadata/src/main/resources/META-INF/spring/" +
+                                                  "org.springframework.boot.autoconfigure." +
+                                                  "AutoConfiguration.imports",
+                                          "MODULE_EVIDENCE_ARTIFACT_UNPARSED"))),
+          buildGradle(
+            "plugins { id 'java' }",
+            "/*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins { id 'java' }",
+            source -> source.path("groovy-settings/build.gradle")),
+          other("include ':hidden'",
+                  source -> source.path("groovy-settings/settings.gradle")),
+          buildGradleKts(
+            "plugins { java }",
+            "/*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins { java }",
+            source -> source.path("kotlin-settings/build.gradle.kts")),
+          parseError("include(\":hidden\")",
+                  source -> source.path("kotlin-settings/settings.gradle.kts")
+                          .beforeRecipeParseError(error -> { })),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>metadata</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>metadata</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("metadata/pom.xml")),
+          other("com.example.HiddenConfiguration",
+                  source -> source.path(
+                          "metadata/src/main/resources/META-INF/spring/" +
+                                  "org.springframework.boot.autoconfigure." +
+                                  "AutoConfiguration.imports"))
+        );
+    }
+
+    @Test
+    void refusesDeclaredChildrenOwnedByAnIncompatibleBuildSystem() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getOutcome,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("gradle-parent", "REFUSED",
+                                          "MODULE_REACTOR_BUILD_MISMATCH"),
+                                  tuple("gradle-parent/child", "ELIGIBLE_FOR_PROFILE",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("maven-parent", "REFUSED",
+                                          "MODULE_REACTOR_BUILD_MISMATCH"),
+                                  tuple("maven-parent/child", "ELIGIBLE_FOR_PROFILE",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"))),
+          buildGradle(
+            "plugins { id 'java' }",
+            "/*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins { id 'java' }",
+            source -> source.path("gradle-parent/build.gradle")),
+          groovy("include ':child'",
+                  source -> source.path("gradle-parent/settings.gradle")),
+          xml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>gradle-child</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("gradle-parent/child/pom.xml")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>maven-parent</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>child</module></modules>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>maven-parent</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>child</module></modules>
+              </project>
+              """,
+            source -> source.path("maven-parent/pom.xml")),
+          buildGradle("plugins { id 'java' }",
+                  source -> source.path("maven-parent/child/build.gradle"))
+        );
+    }
+
+    @Test
+    void refusesGenericUnresolvedMavenAndGradleDependencyOrPluginDeclarations() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("catalog", "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("catalog", "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("catalog", "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("orders", "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("orders", "MODULE_BUILD_EVIDENCE_INCOMPLETE"))),
+          buildGradle(
+            """
+              plugins {
+                  alias libs.plugins.framework
+              }
+
+              def frameworkCoordinate = providers.gradleProperty('frameworkCoordinate')
+              dependencies {
+                  customConfiguration frameworkCoordinate
+                  implementation libs.framework
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 3 blockers; no module changes were applied)~~>*/plugins {
+                  alias libs.plugins.framework
+              }
+
+              def frameworkCoordinate = providers.gradleProperty('frameworkCoordinate')
+              dependencies {
+                  customConfiguration frameworkCoordinate
+                  implementation libs.framework
+              }
+              """,
+            source -> source.path("catalog/build.gradle")),
+          xml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>${framework.group}</groupId>
+                          <artifactId>${framework.artifact}</artifactId>
+                          <version>${framework.version}</version>
+                      </dependency>
+                  </dependencies>
+                  <build><plugins><plugin>
+                      <groupId>${plugin.group}</groupId>
+                      <artifactId>${plugin.artifact}</artifactId>
+                      <version>${plugin.version}</version>
+                  </plugin></plugins></build>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>${framework.group}</groupId>
+                          <artifactId>${framework.artifact}</artifactId>
+                          <version>${framework.version}</version>
+                      </dependency>
+                  </dependencies>
+                  <build><plugins><plugin>
+                      <groupId>${plugin.group}</groupId>
+                      <artifactId>${plugin.artifact}</artifactId>
+                      <version>${plugin.version}</version>
+                  </plugin></plugins></build>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml"))
+        );
+    }
+
+    @Test
+    void acceptsDynamicMavenCoordinatesResolvedAuthoritativelyAsNonSpring() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row ->
+                          assertThat(row.getOutcome()).isEqualTo(
+                                  "ELIGIBLE_FOR_PROFILE"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+                  <properties>
+                      <framework.group>org.junit.jupiter</framework.group>
+                      <framework.artifact>junit-jupiter-api</framework.artifact>
+                      <framework.version>5.10.2</framework.version>
+                  </properties>
+                  <dependencies><dependency>
+                      <groupId>${framework.group}</groupId>
+                      <artifactId>${framework.artifact}</artifactId>
+                      <version>${framework.version}</version>
+                  </dependency></dependencies>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml"))
+        );
+    }
+
+    @Test
+    void refusesDynamicGradleReactorDeclarationsButNotOrdinaryProjectDependencies() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getOutcome,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("dynamic", "REFUSED",
+                                          "MODULE_REACTOR_DECLARATION_UNRESOLVED"),
+                                  tuple("dynamic", "REFUSED",
+                                          "MODULE_REACTOR_DECLARATION_UNRESOLVED"),
+                                  tuple("dynamic", "REFUSED",
+                                          "MODULE_REACTOR_DECLARATION_UNRESOLVED"),
+                                  tuple("orders", "ELIGIBLE_FOR_PROFILE",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"))),
+          buildGradle(
+            "plugins { id 'java' }",
+            "/*~~(REFUSED [MODULE_REFUSED]: 3 blockers; no module changes were applied)~~>*/plugins { id 'java' }",
+            source -> source.path("dynamic/build.gradle")),
+          groovy(
+            """
+              def moduleName = providers.gradleProperty('moduleName')
+              include moduleName
+              includeFlat moduleName
+              includeBuild moduleName
+              """,
+            source -> source.path("dynamic/settings.gradle")),
+          buildGradle(
+            """
+              plugins { id 'java' }
+              dependencies {
+                  implementation project(':shared')
+              }
+              """,
+            source -> source.path("orders/build.gradle"))
+        );
+    }
+
+    @Test
+    void refusesExternalScriptsAndUnknownPluginAccessorsButNotOrdinaryGradleCalls() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("groovy", "Unresolved Gradle external script declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("groovy", "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("kotlin", "Unresolved Gradle external script declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("kotlin", "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("safe", "safe", "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("safe-kotlin", "safe-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"))),
+          buildGradle(
+            """
+              def externalScript = providers.gradleProperty('externalScript')
+              apply from: externalScript
+              plugins {
+                  mysteryFramework
+              }
+              ordinaryMethod(externalScript)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/def externalScript = providers.gradleProperty('externalScript')
+              apply from: externalScript
+              plugins {
+                  mysteryFramework
+              }
+              ordinaryMethod(externalScript)
+              """,
+            source -> source.path("groovy/build.gradle")),
+          buildGradleKts(
+            """
+              val externalScript = providers.gradleProperty("externalScript")
+              apply(from = externalScript)
+              plugins {
+                  mysteryFramework
+              }
+              ordinaryMethod(externalScript)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/val externalScript = providers.gradleProperty("externalScript")
+              apply(from = externalScript)
+              plugins {
+                  mysteryFramework
+              }
+              ordinaryMethod(externalScript)
+              """,
+            source -> source.path("kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              plugins { id 'java' }
+              def dynamicArgument = providers.gradleProperty('dynamicArgument')
+              ordinaryMethod(dynamicArgument)
+              """,
+            source -> source.path("safe/build.gradle")),
+          buildGradleKts(
+            """
+              plugins { `java-library` }
+              val dynamicArgument = providers.gradleProperty("dynamicArgument")
+              ordinaryMethod(dynamicArgument)
+              """,
+            source -> source.path("safe-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void findsSpringInPositionalGradleDependenciesAndReceiverPluginApplyCalls() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getOutcome,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("safe-groovy", "ELIGIBLE_FOR_PROFILE", "safe-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("safe-kotlin", "ELIGIBLE_FOR_PROFILE", "safe-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("spring-groovy", "REFUSED", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("spring-groovy", "REFUSED",
+                                          "org.springframework:spring-context",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("spring-kotlin", "REFUSED", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("spring-kotlin", "REFUSED",
+                                          "org.springframework:spring-context",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradle(
+            """
+              dependencies {
+                  add('implementation', 'org.springframework:spring-context:7.0.8')
+              }
+              pluginManager.apply('org.springframework.boot')
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/dependencies {
+                  add('implementation', 'org.springframework:spring-context:7.0.8')
+              }
+              pluginManager.apply('org.springframework.boot')
+              """,
+            source -> source.path("spring-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              dependencies {
+                  add("implementation", "org.springframework:spring-context:7.0.8")
+              }
+              plugins.apply("org.springframework.boot")
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/dependencies {
+                  add("implementation", "org.springframework:spring-context:7.0.8")
+              }
+              plugins.apply("org.springframework.boot")
+              """,
+            source -> source.path("spring-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              dependencies {
+                  add('implementation', 'org.junit.jupiter:junit-jupiter-api:5.10.2')
+              }
+              plugins.apply('java')
+              """,
+            source -> source.path("safe-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              dependencies {
+                  add("implementation", "org.junit.jupiter:junit-jupiter-api:5.10.2")
+              }
+              pluginManager.apply("java")
+              """,
+            source -> source.path("safe-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void refusesDynamicPositionalGradleDependenciesAndReceiverPluginApplyCalls() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("dynamic-groovy",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("dynamic-groovy",
+                                          "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("dynamic-kotlin",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("dynamic-kotlin",
+                                          "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"))),
+          buildGradle(
+            """
+              def notation = providers.gradleProperty('notation')
+              def pluginId = providers.gradleProperty('pluginId')
+              dependencies {
+                  add('implementation', notation)
+              }
+              plugins.apply(pluginId)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/def notation = providers.gradleProperty('notation')
+              def pluginId = providers.gradleProperty('pluginId')
+              dependencies {
+                  add('implementation', notation)
+              }
+              plugins.apply(pluginId)
+              """,
+            source -> source.path("dynamic-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              val notation = providers.gradleProperty("notation")
+              val pluginId = providers.gradleProperty("pluginId")
+              dependencies {
+                  add("implementation", notation)
+              }
+              pluginManager.apply(pluginId)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/val notation = providers.gradleProperty("notation")
+              val pluginId = providers.gradleProperty("pluginId")
+              dependencies {
+                  add("implementation", notation)
+              }
+              pluginManager.apply(pluginId)
+              """,
+            source -> source.path("dynamic-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void findsSpringDependenciesThroughDependencyHandlerReceiversOnly() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getOutcome,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("ordinary-groovy", "ELIGIBLE_FOR_PROFILE",
+                                          "ordinary-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("ordinary-kotlin", "ELIGIBLE_FOR_PROFILE",
+                                          "ordinary-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("receiver-groovy", "REFUSED",
+                                          "org.springframework:spring-beans",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("receiver-groovy", "REFUSED",
+                                          "org.springframework:spring-context",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("receiver-kotlin", "REFUSED",
+                                          "org.springframework:spring-core",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("receiver-kotlin", "REFUSED",
+                                          "org.springframework:spring-tx",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradle(
+            """
+              dependencies.add('implementation',
+                      'org.springframework:spring-context:7.0.8')
+              project.dependencies.add('runtimeOnly',
+                      'org.springframework:spring-beans:7.0.8')
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/dependencies.add('implementation',
+                      'org.springframework:spring-context:7.0.8')
+              project.dependencies.add('runtimeOnly',
+                      'org.springframework:spring-beans:7.0.8')
+              """,
+            source -> source.path("receiver-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              dependencies.add("implementation",
+                      "org.springframework:spring-core:7.0.8")
+              project.dependencies.add("runtimeOnly",
+                      "org.springframework:spring-tx:7.0.8")
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/dependencies.add("implementation",
+                      "org.springframework:spring-core:7.0.8")
+              project.dependencies.add("runtimeOnly",
+                      "org.springframework:spring-tx:7.0.8")
+              """,
+            source -> source.path("receiver-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              def helper = new Expando()
+              helper.add('implementation',
+                      'org.springframework:spring-context:7.0.8')
+              """,
+            source -> source.path("ordinary-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              fun add(configuration: String, notation: String) = Unit
+              add("implementation", "org.springframework:spring-context:7.0.8")
+              """,
+            source -> source.path("ordinary-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void refusesProviderDependencyHandlerOverloadsButNotOrdinarySameNameCalls() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("ordinary-groovy", "ordinary-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("ordinary-kotlin", "ordinary-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("provider-groovy",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("provider-kotlin",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"))),
+          buildGradle(
+            """
+              def notation = providers.provider {
+                  'org.junit.jupiter:junit-jupiter-api:5.10.2'
+              }
+              dependencies.addProvider('implementation', notation)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/def notation = providers.provider {
+                  'org.junit.jupiter:junit-jupiter-api:5.10.2'
+              }
+              dependencies.addProvider('implementation', notation)
+              """,
+            source -> source.path("provider-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              val notation = providers.provider {
+                  "org.junit.jupiter:junit-jupiter-api:5.10.2"
+              }
+              project.dependencies.addProviderConvertible("implementation", notation)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/val notation = providers.provider {
+                  "org.junit.jupiter:junit-jupiter-api:5.10.2"
+              }
+              project.dependencies.addProviderConvertible("implementation", notation)
+              """,
+            source -> source.path("provider-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              def helper = new Expando()
+              def notation = providers.provider { 'safe' }
+              helper.addProvider('implementation', notation)
+              """,
+            source -> source.path("ordinary-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              fun addProviderConvertible(configuration: String, notation: Any) = Unit
+              val notation = providers.provider { "safe" }
+              addProviderConvertible("implementation", notation)
+              """,
+            source -> source.path("ordinary-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void classifiesDependencyHandlerGetterCallsWithoutCapturingOrdinaryGetters() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("dynamic-kotlin",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("ordinary-groovy", "ordinary-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("safe-kotlin", "safe-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("spring-groovy",
+                                          "org.springframework:spring-context",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradle(
+            """
+              getDependencies().add('implementation',
+                      'org.springframework:spring-context:7.0.8')
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/getDependencies().add('implementation',
+                      'org.springframework:spring-context:7.0.8')
+              """,
+            source -> source.path("spring-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              val notation = providers.gradleProperty("notation")
+              project.getDependencies().add("implementation", notation)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/val notation = providers.gradleProperty("notation")
+              project.getDependencies().add("implementation", notation)
+              """,
+            source -> source.path("dynamic-kotlin/build.gradle.kts")),
+          buildGradleKts(
+            """
+              getDependencies().add("implementation",
+                      "org.junit.jupiter:junit-jupiter-api:5.10.2")
+              """,
+            source -> source.path("safe-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              def helper = new Expando()
+              helper.getDependencies().add('implementation',
+                      'org.springframework:spring-context:7.0.8')
+              """,
+            source -> source.path("ordinary-groovy/build.gradle"))
+        );
+    }
+
+    @Test
+    void acceptsOnlyExactStaticProjectDependencyNotations() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("project-safe-groovy", "project-safe-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("project-safe-kotlin", "project-safe-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("project-unsafe-groovy",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("project-unsafe-groovy",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("project-unsafe-kotlin",
+                                          "Unresolved Gradle dependency declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"))),
+          buildGradle(
+            """
+              dependencies.add('implementation', project(':shared'))
+              dependencies {
+                  runtimeOnly project(':shared')
+              }
+              """,
+            source -> source.path("project-safe-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              project.dependencies.add("implementation", project(":shared"))
+              dependencies {
+                  runtimeOnly(project(":shared"))
+              }
+              """,
+            source -> source.path("project-safe-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              def modulePath = ':shared'
+              def helper = new Expando()
+              dependencies.add('implementation', project(modulePath))
+              dependencies.add('runtimeOnly', helper.project(':shared'))
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/def modulePath = ':shared'
+              def helper = new Expando()
+              dependencies.add('implementation', project(modulePath))
+              dependencies.add('runtimeOnly', helper.project(':shared'))
+              """,
+            source -> source.path("project-unsafe-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              project.dependencies.add("implementation", project(":shared", "extra"))
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/project.dependencies.add("implementation", project(":shared", "extra"))
+              """,
+            source -> source.path("project-unsafe-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void classifiesOwnedPluginBlocksAndPluginHandlerReceiversOnly() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("plugin-dynamic-groovy",
+                                          "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("plugin-dynamic-kotlin",
+                                          "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("plugin-ordinary-groovy", "plugin-ordinary-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("plugin-ordinary-kotlin", "plugin-ordinary-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("plugin-safe-groovy", "plugin-safe-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("plugin-safe-kotlin", "plugin-safe-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("plugin-spring-groovy", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("plugin-spring-kotlin", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradle(
+            """
+              getPluginManager().apply('org.springframework.boot')
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/getPluginManager().apply('org.springframework.boot')
+              """,
+            source -> source.path("plugin-spring-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              project.getPlugins().apply("org.springframework.boot")
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/project.getPlugins().apply("org.springframework.boot")
+              """,
+            source -> source.path("plugin-spring-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              def pluginId = providers.gradleProperty('pluginId')
+              plugins {
+                  apply(pluginId)
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/def pluginId = providers.gradleProperty('pluginId')
+              plugins {
+                  apply(pluginId)
+              }
+              """,
+            source -> source.path("plugin-dynamic-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              val pluginId = providers.gradleProperty("pluginId")
+              project.getPluginManager().apply(pluginId)
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/val pluginId = providers.gradleProperty("pluginId")
+              project.getPluginManager().apply(pluginId)
+              """,
+            source -> source.path("plugin-dynamic-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              getPlugins().apply('java')
+              """,
+            source -> source.path("plugin-safe-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              project.pluginManager.apply("java")
+              """,
+            source -> source.path("plugin-safe-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              def helper = new Expando()
+              helper.apply('org.springframework.boot')
+              helper.id('org.springframework.boot')
+              helper.getPluginManager().apply('org.springframework.boot')
+              """,
+            source -> source.path("plugin-ordinary-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              fun id(value: String) = Unit
+              fun apply(value: String) = Unit
+              id("org.springframework.boot")
+              apply("org.springframework.boot")
+              """,
+            source -> source.path("plugin-ordinary-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void classifiesLegacyNamedApplyOnlyForGradleProjectOwnership() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("ordinary-groovy", "ordinary-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("ordinary-kotlin", "ordinary-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("project-groovy", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("project-kotlin", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradle(
+            """
+              def helper = new Expando()
+              def externalScript = providers.gradleProperty('externalScript')
+              helper.apply plugin: 'org.springframework.boot'
+              helper.apply from: externalScript
+              """,
+            source -> source.path("ordinary-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              class Helper {
+                  fun apply(plugin: String) = Unit
+              }
+              val helper = Helper()
+              helper.apply(plugin = "org.springframework.boot")
+              """,
+            source -> source.path("ordinary-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              project.apply plugin: 'org.springframework.boot'
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/project.apply plugin: 'org.springframework.boot'
+              """,
+            source -> source.path("project-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              apply(plugin = "org.springframework.boot")
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/apply(plugin = "org.springframework.boot")
+              """,
+            source -> source.path("project-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void acceptsLiteralBooleanPluginApplyChainsAndRefusesDynamicValues() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getConstruct,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("dynamic-groovy",
+                                          "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("dynamic-groovy", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("dynamic-kotlin",
+                                          "Unresolved Gradle plugin declaration",
+                                          "MODULE_BUILD_EVIDENCE_INCOMPLETE"),
+                                  tuple("safe-groovy", "safe-groovy",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("safe-kotlin", "safe-kotlin",
+                                          "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("spring-groovy", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"),
+                                  tuple("spring-kotlin", "org.springframework.boot",
+                                          "MODULE_SPRING_BUILD_RESIDUE"))),
+          buildGradle(
+            """
+              plugins {
+                  id 'org.springframework.boot' version '4.0.0' apply false
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins {
+                  id 'org.springframework.boot' version '4.0.0' apply false
+              }
+              """,
+            source -> source.path("spring-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              plugins {
+                  id("org.springframework.boot").apply(false)
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/plugins {
+                  id("org.springframework.boot").apply(false)
+              }
+              """,
+            source -> source.path("spring-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              plugins {
+                  id 'com.example.safe' apply false
+              }
+              """,
+            source -> source.path("safe-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              plugins {
+                  id("com.example.safe").apply(false)
+              }
+              """,
+            source -> source.path("safe-kotlin/build.gradle.kts")),
+          buildGradle(
+            """
+              def shouldApply = providers.gradleProperty('shouldApply')
+              plugins {
+                  id 'org.springframework.boot' apply shouldApply
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 2 blockers; no module changes were applied)~~>*/def shouldApply = providers.gradleProperty('shouldApply')
+              plugins {
+                  id 'org.springframework.boot' apply shouldApply
+              }
+              """,
+            source -> source.path("dynamic-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              val shouldApply = providers.gradleProperty("shouldApply")
+              plugins {
+                  id("com.example.safe").apply(shouldApply)
+              }
+              """,
+            """
+              /*~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>*/val shouldApply = providers.gradleProperty("shouldApply")
+              plugins {
+                  id("com.example.safe").apply(shouldApply)
+              }
+              """,
+            source -> source.path("dynamic-kotlin/build.gradle.kts"))
+        );
+    }
+
+    @Test
+    void doesNotUseHandlerGetterSyntaxAfterIncompatibleAttribution() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  tuple("typed-groovy", "MODULE_ELIGIBLE_FOR_PROFILE"),
+                                  tuple("typed-kotlin", "MODULE_ELIGIBLE_FOR_PROFILE"))),
+          buildGradle(
+            """
+              class LocalDependencies {
+                  void add(String configuration, String notation) { }
+              }
+              class LocalPlugins {
+                  void apply(String pluginId) { }
+              }
+              class LocalProjectLike {
+                  LocalDependencies getDependencies() { new LocalDependencies() }
+                  LocalPlugins getPluginManager() { new LocalPlugins() }
+                  LocalPlugins getPlugins() { new LocalPlugins() }
+                  void inspect() {
+                      getDependencies().add('implementation',
+                              'org.springframework:spring-context:7.0.8')
+                      getPluginManager().apply('org.springframework.boot')
+                      getPlugins().apply('org.springframework.boot')
+                  }
+              }
+              new LocalProjectLike().inspect()
+              """,
+            source -> source.path("typed-groovy/build.gradle")),
+          buildGradleKts(
+            """
+              class LocalDependencies {
+                  fun add(configuration: String, notation: String) = Unit
+              }
+              class LocalPlugins {
+                  fun apply(pluginId: String) = Unit
+              }
+              class LocalProjectLike {
+                  fun getDependencies() = LocalDependencies()
+                  fun getPluginManager() = LocalPlugins()
+                  fun getPlugins() = LocalPlugins()
+                  fun inspect() {
+                      getDependencies().add("implementation",
+                              "org.springframework:spring-context:7.0.8")
+                      getPluginManager().apply("org.springframework.boot")
+                      getPlugins().apply("org.springframework.boot")
+                  }
+              }
+              LocalProjectLike().inspect()
+              """,
+            source -> source.path("typed-kotlin/build.gradle.kts"))
+        );
+    }
+
+    private static SourceSpecs parseError(
+            String before, Consumer<SourceSpec<ParseError>> customize) {
+        Parser.Builder builder = new Parser.Builder(ParseError.class) {
+            @Override
+            public Parser build() {
+                return new Parser() {
+                    @Override
+                    public Stream<SourceFile> parseInputs(
+                            Iterable<Input> sources, Path relativeTo,
+                            ExecutionContext ctx) {
+                        return StreamSupport.stream(sources.spliterator(), false)
+                                .map(input -> parseError(input, relativeTo, ctx));
+                    }
+
+                    private SourceFile parseError(
+                            Input input, Path relativeTo, ExecutionContext ctx) {
+                        try (EncodingDetectingInputStream source = input.getSource(ctx)) {
+                            String text = source.readFully();
+                            Path sourcePath = input.getRelativePath(relativeTo);
+                            PlainText erroneous = PlainText.builder()
+                                    .sourcePath(sourcePath)
+                                    .text(text)
+                                    .build();
+                            return new ParseError(Tree.randomId(), Markers.EMPTY,
+                                    sourcePath,
+                                    input.getFileAttributes(), source.getCharset().name(),
+                                    source.isCharsetBomMarked(), null, text, erroneous);
+                        } catch (IOException exception) {
+                            throw new UncheckedIOException(exception);
+                        }
+                    }
+
+                    @Override
+                    public boolean accept(Path path) {
+                        return true;
+                    }
+
+                    @Override
+                    public Path sourcePathFromSourceText(Path prefix, String sourceCode) {
+                        return prefix.resolve("parse-error.xml");
+                    }
+                };
+            }
+
+            @Override
+            public String getDslName() {
+                return "parse-error";
+            }
+        };
+        SourceSpec<ParseError> source = new SourceSpec<ParseError>(
+                ParseError.class, null, builder, before, null);
+        customize.accept(source);
+        return source;
+    }
+}

--- a/src/test/java/io/github/devanshops/rewrite/helidon/DeclarativeRecipesTest.java
+++ b/src/test/java/io/github/devanshops/rewrite/helidon/DeclarativeRecipesTest.java
@@ -27,6 +27,7 @@ class DeclarativeRecipesTest {
                 .extracting(RecipeDescriptor::getName)
                 .contains(
                         PREFIX + "AnalyzeSpringBootToHelidonMp",
+                        PREFIX + "AssessSpringBootModuleMigrationReadiness",
                         PREFIX + "SpringBoot4ToHelidonMp",
                         PREFIX + "SpringBootToHelidonMp",
                         PREFIX + "SpringBootToHelidonMpViaBoot4");
@@ -75,6 +76,25 @@ class DeclarativeRecipesTest {
         assertThat(descriptor(PREFIX + "FindSpringUsage").getDataTables())
                 .extracting(DataTableDescriptor::getName)
                 .anyMatch(name -> name.endsWith("SpringUsageTable"));
+    }
+
+    @Test
+    void moduleReadinessEntryPointHasNoOptionsAndPublishesItsStablePlanTable() {
+        RecipeDescriptor readiness = descriptor(
+                PREFIX + "AssessSpringBootModuleMigrationReadiness");
+        assertThat(readiness.getOptions()).isEmpty();
+        DataTableDescriptor table = readiness.getDataTables().stream()
+                .filter(candidate -> candidate.getName().endsWith(
+                        "ModuleMigrationReadinessTable"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "ModuleMigrationReadinessTable was not published"));
+        assertThat(table.getColumns())
+                .extracting(ColumnDescriptor::getName)
+                .containsExactly(
+                        "modulePath", "buildSystem", "profile", "outcome",
+                        "sourcePath", "sourceKind", "feature", "construct",
+                        "reasonCode", "reason", "suggestedDirection");
     }
 
     @Test

--- a/src/test/java/io/github/devanshops/rewrite/helidon/ModuleAtomicMigrationRecipeTest.java
+++ b/src/test/java/io/github/devanshops/rewrite/helidon/ModuleAtomicMigrationRecipeTest.java
@@ -1,0 +1,727 @@
+package io.github.devanshops.rewrite.helidon;
+
+import io.github.devanshops.rewrite.helidon.table.ModuleMigrationReadinessTable;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.properties.tree.Properties;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.test.SourceSpecs.text;
+
+class ModuleAtomicMigrationRecipeTest implements RewriteTest {
+    private static final UUID SAME_SOURCE_ID = new UUID(18L, 18L);
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new TestAtomicFamilyRecipe())
+                .cycles(2)
+                .expectedCyclesThatMakeChanges(1);
+    }
+
+    @Test
+    void commitsEveryReplacementAndGenerationForAnEligibleModule() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          text(
+            "first",
+            "migrated:first",
+            source -> source.path("orders/src/main/resources/first.candidate")),
+          text(
+            "second",
+            "migrated:second",
+            source -> source.path("orders/src/testFixtures/resources/second.candidate")),
+          text(
+            null,
+            "generated-by-test-family",
+            source -> source.path(
+                    "orders/src/main/resources/family-generated.txt"))
+        );
+    }
+
+    @Test
+    void oneRefusalCancelsEveryReplacementAndGenerationInTheModule() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          text(
+            "first",
+            source -> source.path("orders/src/main/resources/first.candidate")),
+          properties(
+            """
+              spring.datasource.password=never-expose-this-value
+              """,
+            source -> source.path("orders/src/main/resources/application.properties"))
+        );
+    }
+
+    @Test
+    void keepsEligibleSiblingCommitIndependentFromARefusedModule() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          text(
+            "orders",
+            source -> source.path("orders/src/main/resources/orders.candidate")),
+          properties(
+            """
+              spring.main.banner-mode=off
+              """,
+            source -> source.path("orders/src/main/resources/application.properties")),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>billing</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("billing/pom.xml")),
+          text(
+            "billing",
+            "migrated:billing",
+            source -> source.path("billing/src/main/resources/billing.candidate")),
+          text(
+            null,
+            "generated-by-test-family",
+            source -> source.path(
+                    "billing/src/main/resources/family-generated.txt"))
+        );
+    }
+
+    @Test
+    void generatedPathCollisionRefusesBeforeAnyApplyStep() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~(REFUSED [MODULE_REFUSED]: 1 blocker; no module changes were applied)~~>--><project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          text(
+            "orders",
+            source -> source.path("orders/src/main/resources/orders.candidate")),
+          text(
+            "owned-by-the-application",
+            source -> source.path(
+                    "orders/src/main/resources/family-generated.txt"))
+        );
+    }
+
+    @Test
+    void explicitlyClaimedEvidenceCommitsOnlyAfterProjectedRescanRemovesIt() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          text(
+            "com.example.LegacyAutoConfiguration",
+            "# migrated-by-test-family",
+            source -> source.path(
+                    "orders/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports")),
+          text(
+            null,
+            "generated-by-test-family",
+            source -> source.path(
+                    "orders/src/main/resources/family-generated.txt"))
+        );
+    }
+
+    @Test
+    void claimWithoutReplacementRefusesTheFamilyPlan() {
+        assertMetadataPlanRefusal("claim-without-replacement",
+                "MODULE_PLAN_CONFLICT", 2);
+    }
+
+    @Test
+    void replacementRemovingUnclaimedEvidenceRefusesTheFamilyPlan() {
+        assertMetadataPlanRefusal("remove-without-claim",
+                "MODULE_UNCLAIMED_EVIDENCE_REMOVAL", 1);
+    }
+
+    @Test
+    void duplicateEvidenceClaimRefusesTheFamilyPlan() {
+        assertMetadataPlanRefusal("duplicate-claim", "MODULE_PLAN_CONFLICT", 2);
+    }
+
+    @Test
+    void claimedEvidenceStillPresentInProjectionRefusesTheFamilyPlan() {
+        assertMetadataPlanRefusal("claim-but-retain",
+                "MODULE_CLAIM_NOT_NEUTRALIZED", 2);
+    }
+
+    @Test
+    void duplicateReplacementCandidatesRefuseInsteadOfLastWriteWins() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row ->
+                          assertThat(row.getReasonCode()).isEqualTo(
+                                  "MODULE_PLAN_CONFLICT"))),
+          refusingPom(1),
+          text(
+            "duplicate-replacement",
+            source -> source.path("orders/src/main/resources/orders.candidate"))
+        );
+    }
+
+    @Test
+    void generatedSourceIntroducingSpringResidueRefusesTheFamilyPlan() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row ->
+                          assertThat(row.getReasonCode()).isEqualTo(
+                                  "MODULE_SPRING_METADATA"))),
+          refusingPom(1),
+          text(
+            "introduce-spring-generation",
+            source -> source.path("orders/src/main/resources/generation.trigger"))
+        );
+    }
+
+    @Test
+    void oneClaimCannotRemoveTwoIdenticalEvidenceOccurrences() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row ->
+                          assertThat(row.getReasonCode()).isEqualTo(
+                                  "MODULE_UNCLAIMED_EVIDENCE_REMOVAL"))),
+          refusingPom(1),
+          properties(
+            """
+              spring.duplicate=first
+              spring.duplicate=second
+              """,
+            source -> source.path("orders/src/main/resources/application.properties"))
+        );
+    }
+
+    @Test
+    void sameEvidenceClaimedByOccurrenceAndSemanticKeyRefuses() {
+        assertMetadataPlanRefusal("claim-by-both-apis", "MODULE_PLAN_CONFLICT", 1);
+    }
+
+    @Test
+    void fabricatedReplacementAndRealGenerationRefuseWithoutPartialCommit() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row ->
+                          assertThat(row.getReasonCode()).isEqualTo(
+                                  "MODULE_PLAN_CONFLICT"))),
+          refusingPom(1),
+          text(
+            "fabricated-before",
+            source -> source.path("orders/src/main/resources/orders.candidate"))
+        );
+    }
+
+    @Test
+    void unresolvedClaimRefusesEveryCandidateModule() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getModulePath,
+                                  ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  org.assertj.core.groups.Tuple.tuple(
+                                          "alpha", "MODULE_PLAN_CONFLICT"),
+                                  org.assertj.core.groups.Tuple.tuple(
+                                          "beta", "MODULE_PLAN_CONFLICT"))),
+          refusingPom("alpha", 1),
+          refusingPom("beta", 1),
+          text(
+            "trigger",
+            source -> source.path("beta/src/main/resources/family.invalid-claim")),
+          text(
+            "beta",
+            source -> source.path("beta/src/main/resources/beta.candidate"))
+        );
+    }
+
+    @Test
+    void replacementIntroducingNewSpringResidueRefusesBeforeApply() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows).singleElement().satisfies(row ->
+                          assertThat(row.getReasonCode()).isEqualTo(
+                                  "MODULE_SPRING_METADATA"))),
+          refusingPom(1),
+          text(
+            "# introduce-via-replacement",
+            source -> source.path(
+                    "orders/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"))
+        );
+    }
+
+    @Test
+    void externallyGeneratedPathConflictRefusesTheFamilyPlan() {
+        rewriteRun(
+          spec -> spec.recipes(
+                          new ExternalGeneratedSourceRecipe(),
+                          new TestAtomicFamilyRecipe())
+                  .cycles(1)
+                  .dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                          assertThat(rows).singleElement().satisfies(row ->
+                                  assertThat(row.getReasonCode()).isEqualTo(
+                                          "MODULE_GENERATED_PATH_COLLISION"))),
+          refusingPom(1),
+          text(
+            null,
+            "owned-by-external-generator",
+            source -> source.path(
+                    "orders/src/main/resources/family-generated.txt"))
+        );
+    }
+
+    @Test
+    void externallyGeneratedPathCollidingWithSuppliedSourceRefuses() {
+        rewriteRun(
+          spec -> spec.recipe(new SuppliedPathCollisionFamilyRecipe())
+                  .cycles(1)
+                  .dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                          assertThat(rows).singleElement().satisfies(row ->
+                                  assertThat(row.getReasonCode()).isEqualTo(
+                                          "MODULE_GENERATED_PATH_COLLISION"))),
+          refusingPom(1),
+          text(
+            "owned-by-the-supplied-module",
+            source -> source.path(
+                    "orders/src/main/resources/supplied.txt"))
+        );
+    }
+
+    @Test
+    void externallyGeneratedSourceWithSameIdentityButChangedContentRefuses() {
+        rewriteRun(
+          spec -> spec.recipe(new SameIdentityChangedContentFamilyRecipe())
+                  .cycles(1)
+                  .dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                          assertThat(rows).singleElement().satisfies(row ->
+                                  assertThat(row.getReasonCode()).isEqualTo(
+                                          "MODULE_GENERATED_PATH_COLLISION"))),
+          refusingPom(1),
+          text(
+            "owned-by-the-supplied-module",
+            source -> source.path(
+                            "orders/src/main/resources/same-id.txt")
+                    .mapBeforeRecipe(plainText -> plainText.withId(SAME_SOURCE_ID)))
+        );
+    }
+
+    @Test
+    void exactEquivalentExternalSourceMayDeduplicate() {
+        rewriteRun(
+          spec -> spec.recipe(new SameIdentityEquivalentSourceFamilyRecipe())
+                  .cycles(1)
+                  .dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                          assertThat(rows).singleElement().satisfies(row ->
+                                  assertThat(row.getOutcome()).isEqualTo(
+                                          "ELIGIBLE_FOR_PROFILE"))),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>orders</artifactId>
+                  <version>1.0.0</version>
+              </project>
+              """,
+            source -> source.path("orders/pom.xml")),
+          text(
+            "owned-by-the-supplied-module",
+            source -> source.path(
+                            "orders/src/main/resources/same-id.txt")
+                    .mapBeforeRecipe(plainText -> plainText.withId(SAME_SOURCE_ID))),
+          text(
+            null,
+            "generated-by-test-family",
+            source -> source.path(
+                    "orders/src/main/resources/family-generated.txt"))
+        );
+    }
+
+    @Test
+    void identicalMarkerlessPlanProblemsRemainDistinctAndDeterministic() {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows ->
+                  assertThat(rows)
+                          .extracting(ModuleMigrationReadinessTable.Row::getReasonCode)
+                          .containsExactly(
+                                  "MODULE_PLAN_CONFLICT",
+                                  "MODULE_PLAN_CONFLICT")),
+          refusingPom(2),
+          text(
+            "trigger",
+            source -> source.path(
+                    "orders/src/main/resources/family.two-invalid-claims"))
+        );
+    }
+
+    private void assertMetadataPlanRefusal(String metadata,
+                                           String expectedPlanReason,
+                                           int blockerCount) {
+        rewriteRun(
+          spec -> spec.dataTable(ModuleMigrationReadinessTable.Row.class, rows -> {
+              assertThat(rows).hasSize(blockerCount);
+              assertThat(rows).extracting(ModuleMigrationReadinessTable.Row::getReasonCode)
+                      .contains(expectedPlanReason);
+          }),
+          refusingPom(blockerCount),
+          text(
+            metadata,
+            source -> source.path(
+                    "orders/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"))
+        );
+    }
+
+    private static org.openrewrite.test.SourceSpecs refusingPom(int blockers) {
+        return refusingPom("orders", blockers);
+    }
+
+    private static org.openrewrite.test.SourceSpecs refusingPom(String module, int blockers) {
+        String noun = blockers == 1 ? " blocker" : " blockers";
+        return pomXml(
+          """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>orders</artifactId>
+                <version>1.0.0</version>
+            </project>
+            """,
+          "<!--~~(REFUSED [MODULE_REFUSED]: " + blockers + noun +
+          "; no module changes were applied)~~>--><project>\n" +
+          "    <modelVersion>4.0.0</modelVersion>\n" +
+          "    <groupId>com.example</groupId>\n" +
+          "    <artifactId>orders</artifactId>\n" +
+          "    <version>1.0.0</version>\n" +
+          "</project>",
+          source -> source.path(module + "/pom.xml"));
+    }
+
+    private static class TestAtomicFamilyRecipe extends ModuleAtomicMigrationRecipe {
+        private static final String REPORTED =
+                TestAtomicFamilyRecipe.class.getName() + ".reported";
+        private transient ModuleMigrationReadinessTable readiness =
+                new ModuleMigrationReadinessTable(this);
+
+        @Override
+        public String getDisplayName() {
+            return "Test module-atomic migration family";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Exercises the package-private module-atomic plan/apply seam.";
+        }
+
+        @Override
+        protected void scanMigrationFamily(SourceFile sourceFile,
+                                           ModuleAtomicMigrationCoordinator coordinator,
+                                           ExecutionContext ctx) {
+            String fileName = sourceFile.getSourcePath().getFileName().toString();
+            if (sourceFile instanceof PlainText && fileName.endsWith(".candidate")) {
+                PlainText candidate = (PlainText) sourceFile;
+                if ("fabricated-before".equals(candidate.getText())) {
+                    PlainText fabricated = candidate.withText("fabricated-source");
+                    coordinator.proposeReplacement(fabricated,
+                            fabricated.withText("migrated:fabricated-source"));
+                } else if ("duplicate-replacement".equals(candidate.getText())) {
+                    coordinator.proposeReplacement(candidate,
+                            candidate.withText("first-replacement"));
+                    coordinator.proposeReplacement(candidate,
+                            candidate.withText("second-replacement"));
+                } else if (!candidate.getText().startsWith("migrated:")) {
+                    coordinator.proposeReplacement(candidate,
+                            candidate.withText("migrated:" + candidate.getText()));
+                }
+            }
+            if (sourceFile instanceof PlainText &&
+                    "org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+                            .equals(fileName)) {
+                PlainText metadata = (PlainText) sourceFile;
+                if ("claim-without-replacement".equals(metadata.getText())) {
+                    coordinator.claimEvidence(metadata.getId());
+                } else if ("remove-without-claim".equals(metadata.getText())) {
+                    coordinator.proposeReplacement(metadata,
+                            metadata.withText("# migrated-by-test-family"));
+                } else if ("duplicate-claim".equals(metadata.getText())) {
+                    coordinator.claimEvidence(metadata.getId());
+                    coordinator.claimEvidence(metadata.getId());
+                    coordinator.proposeReplacement(metadata,
+                            metadata.withText("# migrated-by-test-family"));
+                } else if ("claim-but-retain".equals(metadata.getText())) {
+                    coordinator.claimEvidence(metadata.getId());
+                    coordinator.proposeReplacement(metadata,
+                            metadata.withText("still.spring.Registration"));
+                } else if ("claim-by-both-apis".equals(metadata.getText())) {
+                    coordinator.claimEvidence(metadata.getId());
+                    coordinator.claimEvidenceKey(metadataEvidenceKey(metadata));
+                    coordinator.proposeReplacement(metadata,
+                            metadata.withText("# migrated-by-test-family"));
+                } else if ("# introduce-via-replacement".equals(metadata.getText())) {
+                    coordinator.proposeReplacement(metadata,
+                            metadata.withText("com.example.NewSpringRegistration"));
+                } else if (!"# migrated-by-test-family".equals(metadata.getText())) {
+                    coordinator.claimEvidence(metadata.getId());
+                    coordinator.proposeReplacement(metadata,
+                            metadata.withText("# migrated-by-test-family"));
+                }
+            }
+            if (sourceFile instanceof Properties.File) {
+                Properties.File properties = (Properties.File) sourceFile;
+                List<Properties.Content> retained =
+                        new ArrayList<Properties.Content>();
+                Properties.Entry claimed = null;
+                for (Properties.Content content : properties.getContent()) {
+                    if (content instanceof Properties.Entry &&
+                            "spring.duplicate".equals(
+                                    ((Properties.Entry) content).getKey())) {
+                        if (claimed == null) {
+                            claimed = (Properties.Entry) content;
+                        }
+                    } else {
+                        retained.add(content);
+                    }
+                }
+                if (claimed != null) {
+                    coordinator.claimEvidence(claimed.getId());
+                    coordinator.proposeReplacement(properties,
+                            properties.withContent(retained));
+                }
+            }
+            if (fileName.endsWith(".invalid-claim")) {
+                coordinator.claimEvidence(new UUID(0L, 18L));
+            }
+            if (fileName.endsWith(".two-invalid-claims")) {
+                coordinator.claimEvidence(new UUID(0L, 1801L));
+                coordinator.claimEvidence(new UUID(0L, 1802L));
+            }
+            if (sourceFile instanceof PlainText &&
+                    "introduce-spring-generation".equals(
+                            ((PlainText) sourceFile).getText())) {
+                Path root = sourceFile.getSourcePath().getParent().getParent()
+                        .getParent().getParent();
+                coordinator.proposeGeneration(PlainText.builder()
+                        .sourcePath(root.resolve(
+                                "src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"))
+                        .text("com.example.NewSpringRegistration")
+                        .build());
+            }
+            if ("pom.xml".equals(fileName)) {
+                Path root = sourceFile.getSourcePath().getParent();
+                coordinator.proposeGeneration(PlainText.builder()
+                        .sourcePath(root.resolve(
+                                "src/main/resources/family-generated.txt"))
+                        .text("generated-by-test-family")
+                        .build());
+            }
+        }
+
+        private static String metadataEvidenceKey(PlainText metadata) {
+            return metadata.getSourcePath().toString().replace('\\', '/') + '\u0000' +
+                   "SPRING_AUTOCONFIG_IMPORTS" + '\u0000' +
+                   "Spring Boot auto-configuration metadata" + '\u0000' +
+                   "AutoConfiguration.imports entry" + '\u0000' +
+                   "MODULE_SPRING_METADATA";
+        }
+
+        @Override
+        protected void reportFrozenPlan(ModuleAtomicMigrationCoordinator coordinator,
+                                        ExecutionContext ctx) {
+            Set<String> reported = ctx.computeMessageIfAbsent(REPORTED,
+                    key -> ConcurrentHashMap.newKeySet());
+            for (ModuleReadinessDecision decision : coordinator.decisions()) {
+                if (reported.add(decision.rowKey())) {
+                    readiness.insertRow(ctx, decision.toRow());
+                }
+            }
+        }
+    }
+
+    private static final class SuppliedPathCollisionFamilyRecipe
+            extends TestAtomicFamilyRecipe {
+        @Override
+        protected Collection<SourceFile> generatedSourcesForPlanning(
+                ModuleAtomicMigrationCoordinator coordinator,
+                Collection<SourceFile> generatedInThisCycle,
+                ExecutionContext ctx) {
+            List<SourceFile> planning = new ArrayList<SourceFile>(generatedInThisCycle);
+            planning.add(PlainText.builder()
+                    .sourcePath(Path.of(
+                            "orders/src/main/resources/supplied.txt"))
+                    .text("owned-by-an-external-generator")
+                    .build());
+            return planning;
+        }
+    }
+
+    private static final class SameIdentityChangedContentFamilyRecipe
+            extends TestAtomicFamilyRecipe {
+        @Override
+        protected Collection<SourceFile> generatedSourcesForPlanning(
+                ModuleAtomicMigrationCoordinator coordinator,
+                Collection<SourceFile> generatedInThisCycle,
+                ExecutionContext ctx) {
+            List<SourceFile> planning = new ArrayList<SourceFile>(generatedInThisCycle);
+            planning.add(PlainText.builder()
+                    .id(SAME_SOURCE_ID)
+                    .sourcePath(Path.of(
+                            "orders/src/main/resources/same-id.txt"))
+                    .text("changed-by-external-generator")
+                    .build());
+            return planning;
+        }
+    }
+
+    private static final class SameIdentityEquivalentSourceFamilyRecipe
+            extends TestAtomicFamilyRecipe {
+        @Override
+        protected Collection<SourceFile> generatedSourcesForPlanning(
+                ModuleAtomicMigrationCoordinator coordinator,
+                Collection<SourceFile> generatedInThisCycle,
+                ExecutionContext ctx) {
+            List<SourceFile> planning = new ArrayList<SourceFile>(generatedInThisCycle);
+            planning.add(PlainText.builder()
+                    .id(SAME_SOURCE_ID)
+                    .sourcePath(Path.of(
+                            "orders/src/main/resources/same-id.txt"))
+                    .text("owned-by-the-supplied-module")
+                    .build());
+            return planning;
+        }
+    }
+
+    private static final class ExternalGeneratedSourceRecipe
+            extends ScanningRecipe<AtomicBoolean> {
+        @Override
+        public String getDisplayName() {
+            return "Generate an externally owned test source";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Exercises collision composition through the public recipe lifecycle.";
+        }
+
+        @Override
+        public AtomicBoolean getInitialValue(ExecutionContext ctx) {
+            return new AtomicBoolean();
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getScanner(final AtomicBoolean generate) {
+            return new TreeVisitor<Tree, ExecutionContext>() {
+                @Override
+                public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                    if (tree instanceof SourceFile) {
+                        stopAfterPreVisit();
+                        if ("orders/pom.xml".equals(((SourceFile) tree).getSourcePath()
+                                .toString().replace('\\', '/'))) {
+                            generate.set(true);
+                        }
+                    }
+                    return tree;
+                }
+            };
+        }
+
+        @Override
+        public Collection<? extends SourceFile> generate(
+                AtomicBoolean generate,
+                Collection<SourceFile> generatedInThisCycle,
+                ExecutionContext ctx) {
+            if (!generate.get()) {
+                return Collections.emptyList();
+            }
+            return Collections.singletonList(PlainText.builder()
+                    .sourcePath(Path.of(
+                            "orders/src/main/resources/family-generated.txt"))
+                    .text("owned-by-external-generator")
+                    .build());
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean generate) {
+            return TreeVisitor.noop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a separately activatable, no-option, read-only module readiness recipe
- index supplied Maven/Gradle modules across source sets, build topology, resources, XML, registration metadata, launchers, attribution, and Spring residue
- export occurrence-preserving refusal evidence plus one sanitized module marker
- add a package-private frozen-plan coordinator for exact claims, replacements, generated paths, projected-state rescanning, full module rollback, and sibling isolation
- document the conservative profile, privacy boundary, and explicit non-certification limits

## Safety boundary

`ELIGIBLE_FOR_PROFILE` means only that no supplied artifact violates `HELIDON_MP_CONSERVATIVE`; it is not runtime, packaging, deployment, or omitted-file certification. The recipe is absent from canonical top-level compositions and performs no source migration. Real mutating families consume the coordinator in later issues.

This PR is intentionally draft and must not merge before the distribution-only `0.2.1` release tracked by #69. After that release it should be rebased onto the release commit and become part of the `0.3.0` development line.

## Validation

- focused readiness/coordinator/discovery gate: 67/67
- rebased `./mvnw --batch-mode --no-transfer-progress clean verify`: 232/232
- Java 8 production compilation
- focused `@DocumentExample`/two-cycle marker test: 1/1
- disclosure/credential scan and `git diff --check`
- repeated adversarial semantic review: pass
- two-axis review: Standards pass; Spec pass

Closes #18
